### PR TITLE
Add support for --elevation and --font-category

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "dist/index.js",
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build": "stencil build --docs",
     "postbuild": "npm run scss-bundle",
@@ -14,10 +16,9 @@
     "lint": "npm run tslint",
     "precommit": "pretty-quick --staged && npm run lint",
     "pretty-quick": "pretty-quick",
-    "sassdoc":
-      "sassdoc src/components/**/*-theming-mixins.scss -c sassdoc.config.json",
-    "scss-bundle":
-      "scss-bundle -e ./src/components/_components-theming-mixins.scss -d dist/theming/theming-mixins.scss",
+    "sassdoc": "sassdoc src/components/**/*-theming-mixins.scss -c sassdoc.config.json",
+    "scss-bundle": "scss-bundle -e ./src/components/_components-theming-mixins.scss -d dist/theming/theming-mixins.scss",
+    "scss-bundle.watch": "scss-bundle -w ./src/components -e ./src/components/_components-theming-mixins.scss -d dist/theming/theming-mixins.scss",
     "start": "stencil build --dev --watch --serve",
     "start.es5": "stencil build --dev --watch --serve --es5",
     "test": "stencil test --spec --e2e",
@@ -25,8 +26,7 @@
     "test.watch": "stencil test --spec --e2e --watchAll",
     "tslint": "tslint --project . -e \"**/*.spec.ts\"",
     "validate": "npm run lint && npm run test && npm run build",
-    "validate.ci":
-      "npm run lint && npm run test.ci && npm run build --max-workers 1 --debug"
+    "validate.ci": "npm run lint && npm run test.ci && npm run build --max-workers 1 --debug"
   },
   "dependencies": {
     "bootstrap": "^4.3.1",
@@ -70,10 +70,15 @@
   "homepage": "https://github.com/genexuslabs/web-controls-library",
   "jest": {
     "transform": {
-      "^.+\\.(ts|tsx)$":
-        "<rootDir>/node_modules/@stencil/core/testing/jest.preprocessor.js"
+      "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/@stencil/core/testing/jest.preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
-    "moduleFileExtensions": ["ts", "tsx", "js", "json", "jsx"]
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json",
+      "jsx"
+    ]
   }
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -330,6 +330,16 @@ export namespace Components {
      */
     disabled: boolean;
     /**
+     * Used to define the semantic of the element when readonly=true.  Font categories are mapped to semantic HTML elements when rendered:  * `"headline"`: `h1` * `"subheadline"`: `h2` * `"body"`: `p` * `"footnote"`: `footer` * `"caption1"`: `span` * `"caption2"`: `span`
+     */
+    fontCategory:
+      | "headline"
+      | "subheadline"
+      | "body"
+      | "footnote"
+      | "caption1"
+      | "caption2";
+    /**
      * Returns the id of the inner `input` element (if set).
      */
     getNativeInputId: () => Promise<string>;
@@ -398,6 +408,16 @@ export namespace Components {
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
     disabled?: boolean;
+    /**
+     * Used to define the semantic of the element when readonly=true.  Font categories are mapped to semantic HTML elements when rendered:  * `"headline"`: `h1` * `"subheadline"`: `h2` * `"body"`: `p` * `"footnote"`: `footer` * `"caption1"`: `span` * `"caption2"`: `span`
+     */
+    fontCategory?:
+      | "headline"
+      | "subheadline"
+      | "body"
+      | "footnote"
+      | "caption1"
+      | "caption2";
     /**
      * The identifier of the control. Must be unique.
      */

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,4 +1,5 @@
 @import "../common/_base";
+@import "../renders/bootstrap/button/button-render";
 
 gx-button {
   @include visibility(inline-block);

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -48,3 +48,9 @@
     align-items: flex-end;
   }
 }
+
+@mixin elevation() {
+  box-shadow: 0 calc(var(--elevation) * 0.125rem)
+    calc(var(--elevation) * 0.25rem)
+    rgba(0, 0, 0, calc(var(--elevation) * 0.075));
+}

--- a/src/components/common/css-variables-watcher.ts
+++ b/src/components/common/css-variables-watcher.ts
@@ -1,0 +1,83 @@
+import { IComponent } from "./interfaces";
+
+export function cssVariablesWatcher(
+  component: IComponent,
+  properties: ICssVariableWatcherProperty[]
+) {
+  // Set up a MutationObserver to monitor changes on style and class attributes.
+  // When a change occurs on this attributes, the properties listed in
+  // properties are updated with their corresponding CSS variables values.
+  // The properties will be kept in sync with the CSS variables values.
+  // The properties must have the mutable flag set to true.
+  const classObserver = new MutationObserver(
+    (mutationsList: MutationRecord[]) => {
+      for (const mutation of mutationsList) {
+        if (
+          mutation.type === "attributes" &&
+          (mutation.attributeName === "class" ||
+            mutation.attributeName === "style")
+        ) {
+          updatePropertiesFromCss();
+        }
+      }
+    }
+  );
+
+  const updatePropertiesFromCss = () => {
+    for (const prop of properties) {
+      const propCssValue = getComputedStyle(component.element)
+        .getPropertyValue(prop.cssVariableName)
+        .trim();
+      if (propCssValue && component[prop.propertyName] !== propCssValue) {
+        component[prop.propertyName] = propCssValue;
+      }
+    }
+  };
+
+  // componentDidLoad, componentDidUpdate and componentDidUnload are overriden
+  // to start and end observing the mutations, and to update the properties values.
+  overrideMethod(component, "componentDidLoad", {
+    after: () => updatePropertiesFromCss(),
+    before: () => {
+      classObserver.observe(component.element, {
+        attributes: true,
+        childList: false,
+        subtree: false
+      });
+    }
+  });
+
+  overrideMethod(component, "componentDidUpdate", {
+    after: () => updatePropertiesFromCss()
+  });
+
+  overrideMethod(component, "componentDidUnload", {
+    before: () => classObserver.disconnect()
+  });
+}
+
+function overrideMethod(
+  component: IComponent,
+  methodName: string,
+  { before, after }: { before?: () => void; after?: () => void }
+) {
+  const oldMethod = component[methodName];
+  component[methodName] = () => {
+    if (before) {
+      before();
+    }
+
+    if (oldMethod) {
+      oldMethod.call(component);
+    }
+
+    if (after) {
+      after();
+    }
+  };
+}
+
+export interface ICssVariableWatcherProperty {
+  propertyName: string;
+  cssVariableName: string;
+}

--- a/src/components/common/interfaces.ts
+++ b/src/components/common/interfaces.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "@stencil/core";
+import { ComponentInterface, EventEmitter } from "@stencil/core";
 
 export interface IClickableComponent {
   handleClick: (UIEvent) => void;
@@ -13,7 +13,7 @@ export interface IDisableableComponent {
   disabled: boolean;
 }
 
-export interface IComponent {
+export interface IComponent extends ComponentInterface {
   element: HTMLElement;
   render: () => void;
 }

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -9,6 +9,7 @@ import {
 } from "@stencil/core";
 import { EditRender } from "../renders/bootstrap/edit/edit-render";
 import { IFormComponent } from "../common/interfaces";
+import { cssVariablesWatcher } from "../common/css-variables-watcher";
 
 @Component({
   shadow: false,
@@ -18,6 +19,13 @@ import { IFormComponent } from "../common/interfaces";
 export class Edit implements IFormComponent {
   constructor() {
     this.renderer = new EditRender(this);
+
+    cssVariablesWatcher(this, [
+      {
+        cssVariableName: "--font-category",
+        propertyName: "fontCategory"
+      }
+    ]);
   }
 
   private renderer: EditRender;
@@ -46,6 +54,27 @@ export class Edit implements IFormComponent {
    * attribute for `input` elements.
    */
   @Prop() autocorrect: string;
+
+  /**
+   * Used to define the semantic of the element when readonly=true.
+   *
+   * Font categories are mapped to semantic HTML elements when rendered:
+   *
+   * * `"headline"`: `h1`
+   * * `"subheadline"`: `h2`
+   * * `"body"`: `p`
+   * * `"footnote"`: `footer`
+   * * `"caption1"`: `span`
+   * * `"caption2"`: `span`
+   */
+  @Prop({ mutable: true })
+  fontCategory:
+    | "headline"
+    | "subheadline"
+    | "body"
+    | "footnote"
+    | "caption1"
+    | "caption2" = "body";
 
   /**
    * This attribute lets you specify how this element will behave when hidden.

--- a/src/components/form-field/form-field.scss
+++ b/src/components/form-field/form-field.scss
@@ -2,5 +2,5 @@
 @import "../renders/bootstrap/form-field/form-field-render";
 
 gx-form-field {
-  @include visibility(block);
+  @include visibility(flex);
 }

--- a/src/components/group/group.scss
+++ b/src/components/group/group.scss
@@ -1,6 +1,12 @@
 @import "../common/_base";
 
 gx-group {
+  --elevation: 0;
+
   @include visibility(block);
   @include overflowMode();
+
+  & > fieldset {
+    @include elevation();
+  }
 }

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -1,5 +1,11 @@
 @import "../common/_base";
 
 gx-image {
+  --elevation: 0;
+
   @include visibility(inline-flex);
+
+  & > img {
+    @include elevation();
+  }
 }

--- a/src/components/lottie/lottie.scss
+++ b/src/components/lottie/lottie.scss
@@ -1,7 +1,9 @@
+@import "../common/_base";
+
 gx-lottie {
-  display: block;
+  @include visibility(flex);
 
   & > div {
-    height: 100%;
+    flex-grow: 1;
   }
 }

--- a/src/components/renders/bootstrap/button/button-render.scss
+++ b/src/components/renders/bootstrap/button/button-render.scss
@@ -1,0 +1,7 @@
+gx-button {
+  --elevation: 0;
+
+  & > button {
+    @include elevation();
+  }
+}

--- a/src/components/renders/bootstrap/edit/_edit-theming-mixins.scss
+++ b/src/components/renders/bootstrap/edit/_edit-theming-mixins.scss
@@ -10,7 +10,7 @@
   textarea {
     @extend #{$class} !optional;
   }
-  & > span {
+  & > [data-readonly] {
     @extend #{$readonly-class} !optional;
   }
 }

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -101,19 +101,50 @@ export class EditRender implements IRenderer {
       }
     }
 
+    const RedonlyTag = this.getReadonlyTagByFontCtegory() as any;
+
     return [
       <gx-bootstrap />,
-      <span
+      <RedonlyTag
+        key="readonly"
         hidden={!edit.readonly}
-        class={{
-          "form-control-plaintext": true
-        }}
+        class={this.getReadonlyClass()}
+        data-readonly=""
       >
         {edit.value}
-      </span>,
+      </RedonlyTag>,
       editableElement
     ];
+  }
+
+  private getReadonlyTagByFontCtegory() {
+    const tag = fontCategoryTagMap[this.component.fontCategory];
+    if (!tag) {
+      return "span";
+    }
+    return tag;
+  }
+
+  private getReadonlyClass() {
+    if (
+      this.component.fontCategory === "body" ||
+      !this.component.fontCategory
+    ) {
+      return {
+        "form-control-plaintext": true
+      };
+    }
+    return null;
   }
 }
 
 let autoEditId = 0;
+
+const fontCategoryTagMap = {
+  body: "p",
+  caption1: "span",
+  caption2: "span",
+  footnote: "footer",
+  headline: "h1",
+  subheadline: "h2"
+};

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -112,7 +112,7 @@ export class EditRender implements IRenderer {
         data-readonly=""
       >
         {edit.value}
-      </RedonlyTag>,
+      </ReadonlyTag>,
       editableElement
     ];
   }

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -117,7 +117,7 @@ export class EditRender implements IRenderer {
     ];
   }
 
-  private getReadonlyTagByFontCtegory() {
+  private getReadonlyTagByFontCategory() {
     const tag = fontCategoryTagMap[this.component.fontCategory];
     if (!tag) {
       return "span";

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -105,7 +105,7 @@ export class EditRender implements IRenderer {
 
     return [
       <gx-bootstrap />,
-      <RedonlyTag
+      <ReadonlyTag
         key="readonly"
         hidden={!edit.readonly}
         class={this.getReadonlyClass()}

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -101,7 +101,7 @@ export class EditRender implements IRenderer {
       }
     }
 
-    const RedonlyTag = this.getReadonlyTagByFontCtegory() as any;
+    const ReadonlyTag = this.getReadonlyTagByFontCategory() as any;
 
     return [
       <gx-bootstrap />,

--- a/src/components/renders/bootstrap/edit/edit.e2e.ts
+++ b/src/components/renders/bootstrap/edit/edit.e2e.ts
@@ -23,9 +23,34 @@ describe("gx-edit", () => {
     expect(element.value).toEqual("bar");
   });
 
-  // it("should keep input and custom element values in sync", async () => {
-  //   element.value = "foo";
-  //   await page.waitForChanges();
-  //   expect(element.querySelector("input").value).toEqual("foo");
-  // });
+  it("should render as read only", async () => {
+    element.readonly = true;
+    await page.waitForChanges();
+    const readonlyElement = await element.find("[data-readonly]");
+    expect(readonlyElement).toBeTruthy();
+  });
+
+  it("should render as read only using a h1 element - fontCategory property", async () => {
+    await element.setProperty("readonly", true);
+    await element.setProperty("fontCategory", "headline");
+    await page.waitForChanges();
+    const readonlyElement = await element.find("[data-readonly]");
+    expect(readonlyElement.tagName).toBe("H1");
+  });
+
+  it("should render as read only using a h1 element - --font-category CSS property", async () => {
+    await element.setProperty("readonly", true);
+    await element.setProperty("style", "--font-category: headline");
+    await page.waitForChanges();
+    const readonlyElement = await element.find("[data-readonly]");
+    expect(readonlyElement.tagName).toBe("H1");
+  });
+
+  it("should render as read only using a p element - --font-category CSS property", async () => {
+    await element.setProperty("readonly", true);
+    await element.setProperty("style", "--font-category: body");
+    await page.waitForChanges();
+    const readonlyElement = await element.find("[data-readonly]");
+    expect(readonlyElement.tagName).toBe("P");
+  });
 });

--- a/src/components/renders/bootstrap/form-field/_form-field-theming-mixins.scss
+++ b/src/components/renders/bootstrap/form-field/_form-field-theming-mixins.scss
@@ -5,7 +5,7 @@
 /// Helper mixin to ease styling gx-form-field custom elements
 /// @param {string} $class Base class of the field inside the component
 /// @param {string} $label Base class of the label of the component
-/// @param {string} $highlighted Class to be used when the component is in active state
+/// @param {string} $highlighted Class to be used when the component's field is focused
 /// @param {string} $accept-drag-class Class to be used when the component shows that it accepts a drop operation
 /// @param {string} $no-accept-drag-class Class to be used when the component shows that it doesn't accept a drop operation
 /// @param {string} $start-dragging-class Class to be used when the component starts being dragged
@@ -34,7 +34,7 @@
     }
   }
   @if $highlighted != null {
-    &:active {
+    [data-part="field"]:focus {
       @extend #{$highlighted} !optional;
     }
   }

--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -1,4 +1,10 @@
 gx-form-field {
+  --elevation: 0;
+
+  [data-part="field"] {
+    @include elevation();
+  }
+
   &[label-position="float"] > div {
     position: relative;
     margin-bottom: 1em;

--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -60,8 +60,14 @@ gx-form-field {
     }
   }
 
+  & > .form-group {
+    overflow: hidden;
+    flex-grow: 1;
+  }
+
   & > .row {
     overflow: hidden;
+    flex-grow: 1;
     & > div {
       & > gx-image {
         max-height: 100%;

--- a/src/components/renders/bootstrap/tab/tab-render.scss
+++ b/src/components/renders/bootstrap/tab/tab-render.scss
@@ -1,0 +1,13 @@
+gx-tab {
+  --elevation: 0;
+  --tab-strip-elevation: 0;
+
+  & > div {
+    @include elevation();
+
+    & > .nav-tabs {
+      --elevation: var(--tab-strip-elevation);
+      @include elevation();
+    }
+  }
+}

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -1,4 +1,5 @@
 @import "../common/_base";
+@import "../renders/bootstrap/tab/tab-render";
 
 gx-tab {
   @include visibility(block);

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -1,5 +1,8 @@
 @import "../common/_base";
 
 gx-table {
+  --elevation: 0;
+
   @include visibility(grid);
+  @include elevation();
 }

--- a/src/components/textblock/textblock.scss
+++ b/src/components/textblock/textblock.scss
@@ -1,5 +1,11 @@
 @import "../common/_base";
 
 gx-textblock {
+  --elevation: 0;
+
   @include visibility(inline-block);
+
+  & > .content {
+    @include elevation();
+  }
 }


### PR DESCRIPTION
Added support for first CSS variables (--elevation and --font-category) and implemented a mechanism to allow components to synchronize the value of a CSS variable with a property.

To keep a CSS variable in sync with a component property, first a mutable property must be declared.

```js
  @Prop({ mutable: true })
  fontCategory:
    | "headline"
    | "subheadline"
    | "body"
    | "footnote"
    | "caption1"
    | "caption2" = "body";
```

Then, calling `cssVariablesWatcher` in the constructor, specify the mapping:

```js
    cssVariablesWatcher(this, [
      {
        cssVariableName: "--font-category",
        propertyName: "fontCategory"
      }
    ]);
```

By using cssVariableWatcher, every time the style and clas attributes are changed, the CSS variable is read and, if changed, the mapped property is updated.

Some other minor changes to theming mixins were done too.