### PR TITLE
Fix race condition when initializing lazySizes

### DIFF
--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -19,12 +19,6 @@ export class Image
     IDisableableComponent,
     IVisibilityComponent,
     IClickableComponent {
-  constructor() {
-    lazySizes.cfg.lazyClass = LAZY_LOAD_CLASS;
-    lazySizes.cfg.loadingClass = LAZY_LOADING_CLASS;
-    lazySizes.cfg.loadedClass = LAZY_LOADED_CLASS;
-  }
-
   @Element() element;
 
   /**
@@ -116,3 +110,7 @@ export class Image
 const LAZY_LOAD_CLASS = "gx-lazyload";
 const LAZY_LOADING_CLASS = "gx-lazyloading";
 const LAZY_LOADED_CLASS = "gx-lazyloaded";
+
+lazySizes.cfg.lazyClass = LAZY_LOAD_CLASS;
+lazySizes.cfg.loadingClass = LAZY_LOADING_CLASS;
+lazySizes.cfg.loadedClass = LAZY_LOADED_CLASS;

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -109,8 +109,12 @@ export class Image
   }
 
   private shouldLazyLoad(): boolean {
+    if (!this.lazyLoad) {
+      return false;
+    }
+
     const img: HTMLImageElement = this.element.querySelector("img");
-    return this.lazyLoad && (!img || img.classList.contains(LAZY_LOAD_CLASS));
+    return !img || img.classList.contains(LAZY_LOAD_CLASS);
   }
 }
 

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -19,7 +19,7 @@ export class Image
     IDisableableComponent,
     IVisibilityComponent,
     IClickableComponent {
-  @Element() element;
+  @Element() element: HTMLGxImageElement;
 
   /**
    * This attribute lets you specify the alternative text.
@@ -88,15 +88,17 @@ export class Image
   }
 
   render() {
+    const shouldLazyLoad = this.shouldLazyLoad();
+
     const body = [
       <img
         class={{
-          [LAZY_LOAD_CLASS]: this.lazyLoad,
+          [LAZY_LOAD_CLASS]: shouldLazyLoad,
           [this.cssClass]: !!this.cssClass
         }}
         onClick={this.handleClick.bind(this)}
-        data-src={this.lazyLoad ? this.src : undefined}
-        src={!this.lazyLoad ? this.src : undefined}
+        data-src={shouldLazyLoad ? this.src : undefined}
+        src={!shouldLazyLoad ? this.src : undefined}
         alt={this.alt ? this.alt : ""}
         width={this.width}
         height={this.height}
@@ -104,6 +106,11 @@ export class Image
       <span />
     ];
     return body;
+  }
+
+  private shouldLazyLoad(): boolean {
+    const img: HTMLImageElement = this.element.querySelector("img");
+    return this.lazyLoad && (!img || img.classList.contains(LAZY_LOAD_CLASS));
   }
 }
 


### PR DESCRIPTION
Changed the moment when lazySizes config is initialized. Now it's done immediately after the component's class is defined, instead of the constructor.
This is to avoid a race condition when `gx-image` components are created dynamically.