### PR TITLE
Add support for scale type property in gx-image component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -866,6 +866,10 @@ export namespace Components {
      */
     lowResolutionSrc: string;
     /**
+     * This attribute allows specifing how the image is sized according to its container. `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property. The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
+     */
+    scaleType: "contain" | "cover" | "fill" | "none" | "tile";
+    /**
      * This attribute lets you specify the SRC.
      */
     src: string;
@@ -907,6 +911,10 @@ export namespace Components {
      * Emitted when the element is clicked.
      */
     onOnClick?: (event: CustomEvent) => void;
+    /**
+     * This attribute allows specifing how the image is sized according to its container. `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property. The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
+     */
+    scaleType?: "contain" | "cover" | "fill" | "none" | "tile";
     /**
      * This attribute lets you specify the SRC.
      */

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -15,6 +15,16 @@ gx-image {
     object-fit: var(--image-scale-type, contain);
   }
 
+  .gx-image-tile {
+    width: 100% !important;
+    height: 100% !important;
+    padding-left: 100% !important;
+    box-sizing: border-box !important;
+    display: inline-block !important;
+    background-position: 0 !important;
+    background-repeat: repeat;
+  }
+
   .gx-lazyload:not([src]) {
     visibility: hidden;
   }

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -5,8 +5,14 @@ gx-image {
 
   @include visibility(inline-flex);
 
+  justify-content: center;
+  align-items: center;
+
   & > img {
     @include elevation();
+    height: 100%;
+    width: 100%;
+    object-fit: var(--image-scale-type, contain);
   }
 
   .gx-lazyload:not([src]) {

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -7,6 +7,7 @@ import {
   IDisableableComponent,
   IVisibilityComponent
 } from "../common/interfaces";
+import { cssVariablesWatcher } from "../common/css-variables-watcher";
 
 @Component({
   shadow: false,
@@ -19,6 +20,15 @@ export class Image
     IDisableableComponent,
     IVisibilityComponent,
     IClickableComponent {
+  constructor() {
+    cssVariablesWatcher(this, [
+      {
+        cssVariableName: "--image-scale-type",
+        propertyName: "scaleType"
+      }
+    ]);
+  }
+
   @Element() element: HTMLGxImageElement;
 
   /**
@@ -64,6 +74,18 @@ export class Image
   @Prop() lowResolutionSrc = "";
 
   /**
+   * This attribute allows specifing how the image is sized according to its container.
+   * `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property.
+   * The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
+   */
+  @Prop({ mutable: true }) scaleType:
+    | "contain"
+    | "cover"
+    | "fill"
+    | "none"
+    | "tile";
+
+  /**
    * This attribute lets you specify the SRC.
    */
   @Prop() src = "";
@@ -94,8 +116,14 @@ export class Image
       <img
         class={{
           [LAZY_LOAD_CLASS]: shouldLazyLoad,
-          [this.cssClass]: !!this.cssClass
+          [this.cssClass]: !!this.cssClass,
+          "gx-image-tile": this.scaleType === "tile"
         }}
+        style={
+          this.scaleType === "tile"
+            ? { backgroundImage: `url(${this.src})` }
+            : { objectFit: this.scaleType }
+        }
         onClick={this.handleClick.bind(this)}
         data-src={shouldLazyLoad ? this.src : undefined}
         src={!shouldLazyLoad ? this.src : undefined}


### PR DESCRIPTION
Added support for the Scale Type property in `gx-image` component.
All of the supported values of the property but `"tile"` are mapped directly to the `object-fit` CSS property.

Supporting the `"tile"` value requires extra logic, so a `scaleType` property was defined in the `gx-image` component to be able to read the value of the `--image-scale-type`  CSS variable, to create the tile effect using `background-image` and `background-repeat` properties.

