### PR TITLE
Fix gx-table cells horizontal and vertical align

### DIFF
--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -33,19 +33,19 @@
   }
 
   &[align="center"] {
-    justify-content: center;
-  }
-
-  &[align="right"] {
-    justify-content: flex-end;
-  }
-
-  &[valign="middle"] {
     align-items: center;
   }
 
-  &[valign="bottom"] {
+  &[align="right"] {
     align-items: flex-end;
+  }
+
+  &[valign="middle"] {
+    justify-content: center;
+  }
+
+  &[valign="bottom"] {
+    justify-content: flex-end;
   }
 }
 

--- a/src/components/table-cell/table-cell.scss
+++ b/src/components/table-cell/table-cell.scss
@@ -2,4 +2,6 @@
 
 gx-table-cell {
   @include containerCell();
+
+  flex-direction: column;
 }


### PR DESCRIPTION
Cells of `gx-table` component weren't correctly aligning their child items according to the values of the `align` and `valign` attributes.

