### PR TITLE
Fix various sizing issues with gx-table-cell children

### DIFF
--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -28,7 +28,7 @@
   &:not([align]),
   &[align="left"] {
     & > * {
-      flex-grow: 1;
+      flex: 1;
     }
   }
 

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -33,19 +33,19 @@
   }
 
   &[align="center"] {
-    align-items: center;
-  }
-
-  &[align="right"] {
-    align-items: flex-end;
-  }
-
-  &[valign="middle"] {
     justify-content: center;
   }
 
-  &[valign="bottom"] {
+  &[align="right"] {
     justify-content: flex-end;
+  }
+
+  &[valign="middle"] {
+    align-items: center;
+  }
+
+  &[valign="bottom"] {
+    align-items: flex-end;
   }
 }
 

--- a/src/components/edit/edit.scss
+++ b/src/components/edit/edit.scss
@@ -4,4 +4,5 @@
 gx-edit {
   @include visibility(flex);
   align-items: stretch;
+  flex: 1;
 }

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -2,10 +2,6 @@
 
 gx-image {
   --elevation: 0;
-  --margin-top: 0px;
-  --margin-right: 0px;
-  --margin-bottom: 0px;
-  --margin-left: 0px;
 
   @include visibility(inline-flex);
 
@@ -18,8 +14,8 @@ gx-image {
     margin-right: var(--margin-right);
     margin-bottom: var(--margin-bottom);
     margin-left: var(--margin-left);
-    max-height: calc(100% - var(--margin-top) - var(--margin-bottom));
-    max-width: calc(100% - var(--margin-right) - var(--margin-left));
+    max-height: calc(100% - var(--margin-top, 0px) - var(--margin-bottom, 0px));
+    max-width: calc(100% - var(--margin-right, 0px) - var(--margin-left, 0px));
     object-fit: var(--image-scale-type, contain);
   }
 

--- a/src/components/password-edit/password-edit.scss
+++ b/src/components/password-edit/password-edit.scss
@@ -2,4 +2,5 @@
 
 gx-password-edit {
   @include visibility(block);
+  flex: 1;
 }

--- a/src/components/renders/bootstrap/card/card-render.scss
+++ b/src/components/renders/bootstrap/card/card-render.scss
@@ -19,4 +19,10 @@ gx-card {
       border: 0;
     }
   }
+
+  & > .card {
+    & > [slot="body"] {
+      display: flex;
+    }
+  }
 }

--- a/src/components/renders/bootstrap/edit/edit-render.scss
+++ b/src/components/renders/bootstrap/edit/edit-render.scss
@@ -1,8 +1,32 @@
 gx-edit {
+  [data-native-element] {
+    margin-top: var(--margin-top, 0);
+    margin-bottom: var(--margin-bottom, 0);
+  }
+
   &:not([show-trigger]),
   &[show-trigger="false"] {
     [slot="trigger-content"] {
       display: none;
     }
+
+    [data-native-element] {
+      margin-right: var(--margin-right, 0);
+      margin-left: var(--margin-left, 0);
+    }
+  }
+
+  &[show-trigger],
+  &[show-trigger="true"] {
+    .input-group {
+      margin-right: var(--margin-right, 0);
+      margin-left: var(--margin-left, 0);
+    }
+  }
+
+  [data-readonly] {
+    margin: 0;
+    padding: 0;
+    line-height: 1.2;
   }
 }

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -105,12 +105,7 @@ export class EditRender implements IRenderer {
 
     return [
       <gx-bootstrap />,
-      <ReadonlyTag
-        key="readonly"
-        hidden={!edit.readonly}
-        class={this.getReadonlyClass()}
-        data-readonly=""
-      >
+      <ReadonlyTag key="readonly" hidden={!edit.readonly} data-readonly="">
         {edit.value}
       </ReadonlyTag>,
       editableElement
@@ -123,18 +118,6 @@ export class EditRender implements IRenderer {
       return "span";
     }
     return tag;
-  }
-
-  private getReadonlyClass() {
-    if (
-      this.component.fontCategory === "body" ||
-      !this.component.fontCategory
-    ) {
-      return {
-        "form-control-plaintext": true
-      };
-    }
-    return null;
   }
 }
 

--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -68,6 +68,7 @@ gx-form-field {
 
   & > .form-group {
     overflow: hidden;
+    max-height: 100%;
   }
 
   & > .row {

--- a/src/components/table-cell/table-cell.scss
+++ b/src/components/table-cell/table-cell.scss
@@ -3,5 +3,5 @@
 gx-table-cell {
   @include containerCell();
 
-  flex-direction: column;
+  flex-direction: row;
 }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -5,4 +5,6 @@ gx-table {
 
   @include visibility(grid);
   @include elevation();
+
+  flex: 1;
 }


### PR DESCRIPTION
Children elements of `gx-table-cell` had sizing issues that resulted in wrong layouts. Most of the issues had to do with default flex values.

Also fixed how the margins of the `gx-edit` component are set, and adjusted the fallback value of the `gx-image` component.
