### PR TITLE
Fix default overflow for gx-table-cell

### DIFF
--- a/src/components/table-cell/table-cell.scss
+++ b/src/components/table-cell/table-cell.scss
@@ -1,6 +1,7 @@
 @import "../common/_base";
 
 gx-table-cell {
+  overflow: hidden;
   @include containerCell();
 
   flex-direction: row;


### PR DESCRIPTION
A default value for the `overflow` CSS property was missing for those cases when the `overflow-mode` attribute isn't specified.
