### PR TITLE
Fix icon not working when iconSrc property used

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1605,7 +1605,7 @@ export namespace Components {
     /**
      * Returns the id of the inner `input` element (if set).
      */
-    getNativeInputId: () => Promise<any>;
+    getNativeInputId: () => Promise<string>;
     /**
      * The control id. Must be unique per control!
      */
@@ -1615,11 +1615,11 @@ export namespace Components {
      */
     invisibleMode: "collapse" | "keep-space";
     /**
-     * The current value displayed by the component.
+     * This porpoerty is required if you want to display a score. >E.g: In a score of 4/5 stars the `maxValue` is `5` and the `value` is `4`
      */
     maxValue: number;
     /**
-     * This attribute i0ndicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements. _Disable by default_
+     * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements. _Disable by default_
      */
     readonly: boolean;
     /**
@@ -1641,7 +1641,7 @@ export namespace Components {
      */
     invisibleMode?: "collapse" | "keep-space";
     /**
-     * The current value displayed by the component.
+     * This porpoerty is required if you want to display a score. >E.g: In a score of 4/5 stars the `maxValue` is `5` and the `value` is `4`
      */
     maxValue?: number;
     /**
@@ -1649,7 +1649,7 @@ export namespace Components {
      */
     onInput?: (event: CustomEvent) => void;
     /**
-     * This attribute i0ndicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements. _Disable by default_
+     * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements. _Disable by default_
      */
     readonly?: boolean;
     /**

--- a/src/components/renders/bootstrap/navbar-link/navbar-link-render.scss
+++ b/src/components/renders/bootstrap/navbar-link/navbar-link-render.scss
@@ -1,6 +1,7 @@
 gx-navbar-link {
   --gx-navbar-link-icon-size: 24px;
   a.nav-link[data-has-icon] {
+    display: inline-flex;
     &::before {
       content: "";
       display: inline-block;
@@ -9,22 +10,12 @@ gx-navbar-link {
       background-image: var(--gx-navbar-link-icon-src);
       background-position: center center;
       background-repeat: no-repeat;
-      background-size: cover;
+      background-size: contain;
       margin-right: 5px;
       position: relative;
       top: -3px;
-      vertical-align: middle;
-    }
-
-    @media (min-width: 576px) {
-      &::before {
-        content: "";
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        text-align: center;
-        top: 0;
-      }
+      align-self: center;
+      flex-shrink: 0;
     }
   }
 }

--- a/src/components/renders/bootstrap/navbar-link/navbar-link-render.scss
+++ b/src/components/renders/bootstrap/navbar-link/navbar-link-render.scss
@@ -1,7 +1,7 @@
 gx-navbar-link {
   --gx-navbar-link-icon-size: 24px;
-  &[icon-src] {
-    a.nav-link::before {
+  a.nav-link[data-has-icon] {
+    &::before {
       content: "";
       display: inline-block;
       height: var(--gx-navbar-link-icon-size);
@@ -17,7 +17,7 @@ gx-navbar-link {
     }
 
     @media (min-width: 576px) {
-      a.nav-link::before {
+      &::before {
         content: "";
         display: block;
         margin-left: auto;

--- a/src/components/renders/bootstrap/navbar-link/navbar-link-render.tsx
+++ b/src/components/renders/bootstrap/navbar-link/navbar-link-render.tsx
@@ -28,7 +28,7 @@ export class NavBarLinkRender implements IRenderer {
         href={this.component.href}
         onClick={this.handleClick.bind(this)}
         style={{
-          "--gx-navbar-link-icon-src": `url(${this.component.iconSrc})`
+          "--gx-navbar-link-icon-src": `url("${this.component.iconSrc}")`
         }}
         data-has-icon={!!this.component.iconSrc}
       >

--- a/src/components/renders/bootstrap/navbar-link/navbar-link-render.tsx
+++ b/src/components/renders/bootstrap/navbar-link/navbar-link-render.tsx
@@ -30,6 +30,7 @@ export class NavBarLinkRender implements IRenderer {
         style={{
           "--gx-navbar-link-icon-src": `url(${this.component.iconSrc})`
         }}
+        data-has-icon={!!this.component.iconSrc}
       >
         <slot />
       </a>

--- a/src/components/renders/bootstrap/navbar-link/navbar-link.e2e.ts
+++ b/src/components/renders/bootstrap/navbar-link/navbar-link.e2e.ts
@@ -36,4 +36,10 @@ describe("gx-navbar-link", () => {
     await page.waitForChanges();
     expect(await page.find("a")).toHaveClass("foo-class");
   });
+
+  it("should render an icon", async () => {
+    await element.setAttribute("icon-src", "image.png");
+    await page.waitForChanges();
+    expect(await element.getAttribute("data-has-icon")).toBeDefined();
+  });
 });


### PR DESCRIPTION
If the icon of the `gx-navbar-link` component was set using only the `iconSrc` property, the icon wouldn't get displayed.
