### PR TITLE
Fix button mixin active state selector

### DIFF
--- a/src/components/renders/bootstrap/button/_button-theming-mixins.scss
+++ b/src/components/renders/bootstrap/button/_button-theming-mixins.scss
@@ -10,7 +10,7 @@
     @extend #{$class} !optional;
 
     @if ($highlighted != null) {
-      &:active {
+      &:not(:disabled):not(.disabled):active {
         @extend #{$highlighted} !optional;
       }
     }


### PR DESCRIPTION
Now the selector is more specific to have more precedence over the Bootstrap's one