### PR TITLE
Fix navbar links not displaying always as links

### DIFF
--- a/src/components/renders/bootstrap/navbar-link/navbar-link-render.scss
+++ b/src/components/renders/bootstrap/navbar-link/navbar-link-render.scss
@@ -1,21 +1,24 @@
 gx-navbar-link {
   --gx-navbar-link-icon-size: 24px;
-  a.nav-link[data-has-icon] {
-    display: inline-flex;
-    &::before {
-      content: "";
-      display: inline-block;
-      height: var(--gx-navbar-link-icon-size);
-      width: var(--gx-navbar-link-icon-size);
-      background-image: var(--gx-navbar-link-icon-src);
-      background-position: center center;
-      background-repeat: no-repeat;
-      background-size: contain;
-      margin-right: 5px;
-      position: relative;
-      top: -3px;
-      align-self: center;
-      flex-shrink: 0;
+  a.nav-link {
+    cursor: pointer;
+    &[data-has-icon] {
+      display: inline-flex;
+      &::before {
+        content: "";
+        display: inline-block;
+        height: var(--gx-navbar-link-icon-size);
+        width: var(--gx-navbar-link-icon-size);
+        background-image: var(--gx-navbar-link-icon-src);
+        background-position: center center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        margin-right: 5px;
+        position: relative;
+        top: -3px;
+        align-self: center;
+        flex-shrink: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
If the navbar link had no `href` set, it would not show the cursor as pointer.
The default style is now `cursor: pointer`
