### PR TITLE
Add !important to display property for visibility

### DIFF
--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -2,10 +2,10 @@
   display: $display;
 
   &[hidden] {
-    display: none;
+    display: none !important;
 
     &[invisible-mode="keep-space"] {
-      display: $display;
+      display: $display !important;
       visibility: hidden;
     }
   }


### PR DESCRIPTION
Add the !important keyword to the display property to the SASS rules that control component's visibility according to the invisibleMode property