### PR TITLE
Fix error in grid theming mixin

### DIFF
--- a/src/components/grid-base/grid-base-theming-mixins.scss
+++ b/src/components/grid-base/grid-base-theming-mixins.scss
@@ -16,7 +16,6 @@
   $odd-row: null,
   $even-row: null,
   $loading-animation: null,
-  $horizontal-line: null,
   $group-separator: null,
   $horizontal-line: null
 ) {


### PR DESCRIPTION
An named parameter was declared twice in `gx-grid-base` theming mixin.
