### PR TITLE
 Set a size to images inside gx-button component

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -4,6 +4,8 @@
 gx-button {
   @include visibility(inline-block);
 
+  --gx-button-image-size: 16px;
+
   vertical-align: middle;
 
   &[disabled] {
@@ -24,8 +26,8 @@ gx-button {
     position: relative;
 
     & > img {
-      height: 16px;
-      width: 16px;
+      height: var(--gx-button-image-size);
+      width: var(--gx-button-image-size);
       object-fit: contain;
 
       &[slot="disabled-image"] {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -23,8 +23,14 @@ gx-button {
     flex-direction: column;
     position: relative;
 
-    & > img[slot="disabled-image"] {
-      display: none;
+    & > img {
+      height: 16px;
+      width: 16px;
+      object-fit: contain;
+
+      &[slot="disabled-image"] {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
The default width and height is set using the `--gx-button-image-size` to allow end users to customize the size.
