### PR TITLE
Add gx-action-sheet component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,6 +9,26 @@ import { TimerState } from "./components/chronometer/chronometer-timer-state";
 import { SwiperOptions } from "swiper";
 
 export namespace Components {
+  interface GxActionSheet {
+    /**
+     * This attribute lets you specify the label for the close button. Important for accessibility.
+     */
+    closeButtonLabel: string;
+    /**
+     * This attribute lets you specify if the action sheet is opened or closed.
+     */
+    opened: boolean;
+  }
+  interface GxActionSheetItem {
+    /**
+     * This attribute lets you specify the type of action. `"cancel"` and `"destructive"` are style differently
+     */
+    actionType: "cancel" | "default" | "destructive";
+    /**
+     * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+     */
+    disabled: boolean;
+  }
   interface GxBootstrap {}
   interface GxButton {
     /**
@@ -961,6 +981,22 @@ export namespace Components {
 }
 
 declare global {
+  interface HTMLGxActionSheetElement
+    extends Components.GxActionSheet,
+      HTMLStencilElement {}
+  var HTMLGxActionSheetElement: {
+    prototype: HTMLGxActionSheetElement;
+    new (): HTMLGxActionSheetElement;
+  };
+
+  interface HTMLGxActionSheetItemElement
+    extends Components.GxActionSheetItem,
+      HTMLStencilElement {}
+  var HTMLGxActionSheetItemElement: {
+    prototype: HTMLGxActionSheetItemElement;
+    new (): HTMLGxActionSheetItemElement;
+  };
+
   interface HTMLGxBootstrapElement
     extends Components.GxBootstrap,
       HTMLStencilElement {}
@@ -1241,6 +1277,8 @@ declare global {
     new (): HTMLGxTextblockElement;
   };
   interface HTMLElementTagNameMap {
+    "gx-action-sheet": HTMLGxActionSheetElement;
+    "gx-action-sheet-item": HTMLGxActionSheetItemElement;
     "gx-bootstrap": HTMLGxBootstrapElement;
     "gx-button": HTMLGxButtonElement;
     "gx-canvas": HTMLGxCanvasElement;
@@ -1282,6 +1320,40 @@ declare global {
 }
 
 declare namespace LocalJSX {
+  interface GxActionSheet
+    extends JSXBase.HTMLAttributes<HTMLGxActionSheetElement> {
+    /**
+     * This attribute lets you specify the label for the close button. Important for accessibility.
+     */
+    closeButtonLabel?: string;
+    /**
+     * Fired when the action sheet is closed
+     */
+    onOnClose?: (event: CustomEvent<any>) => void;
+    /**
+     * Fired when the action sheet is opened
+     */
+    onOnOpen?: (event: CustomEvent<any>) => void;
+    /**
+     * This attribute lets you specify if the action sheet is opened or closed.
+     */
+    opened?: boolean;
+  }
+  interface GxActionSheetItem
+    extends JSXBase.HTMLAttributes<HTMLGxActionSheetItemElement> {
+    /**
+     * This attribute lets you specify the type of action. `"cancel"` and `"destructive"` are style differently
+     */
+    actionType?: "cancel" | "default" | "destructive";
+    /**
+     * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+     */
+    disabled?: boolean;
+    /**
+     * Fired when the action sheet item is clicked
+     */
+    onOnClick?: (event: CustomEvent<any>) => void;
+  }
   interface GxBootstrap
     extends JSXBase.HTMLAttributes<HTMLGxBootstrapElement> {}
   interface GxButton extends JSXBase.HTMLAttributes<HTMLGxButtonElement> {
@@ -1323,6 +1395,26 @@ declare namespace LocalJSX {
      * Emitted when the element is clicked.
      */
     onOnClick?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped.
+     */
+    onOnSwipe?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped downward direction.
+     */
+    onOnSwipeDown?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped left direction..
+     */
+    onOnSwipeLeft?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped right direction.
+     */
+    onOnSwipeRight?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped in upward direction.
+     */
+    onOnSwipeUp?: (event: CustomEvent<any>) => void;
   }
   interface GxCanvasCell
     extends JSXBase.HTMLAttributes<HTMLGxCanvasCellElement> {
@@ -2303,6 +2395,26 @@ declare namespace LocalJSX {
      */
     onOnClick?: (event: CustomEvent<any>) => void;
     /**
+     * Emitted when the element is swiped.
+     */
+    onOnSwipe?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped downward direction.
+     */
+    onOnSwipeDown?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped left direction..
+     */
+    onOnSwipeLeft?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped right direction.
+     */
+    onOnSwipeRight?: (event: CustomEvent<any>) => void;
+    /**
+     * Emitted when the element is swiped in upward direction.
+     */
+    onOnSwipeUp?: (event: CustomEvent<any>) => void;
+    /**
      * Like the `grid-templates-rows` CSS property, this attribute defines the rows of the grid with a space-separated list of values. The values represent the height of each row.
      */
     rowsTemplate?: string;
@@ -2345,6 +2457,8 @@ declare namespace LocalJSX {
   }
 
   interface IntrinsicElements {
+    "gx-action-sheet": GxActionSheet;
+    "gx-action-sheet-item": GxActionSheetItem;
     "gx-bootstrap": GxBootstrap;
     "gx-button": GxButton;
     "gx-canvas": GxCanvas;

--- a/src/components/action-sheet-item/action-sheet-item.scss
+++ b/src/components/action-sheet-item/action-sheet-item.scss
@@ -1,0 +1,6 @@
+@import "../common/_base";
+@import "../renders/bootstrap/action-sheet-item/action-sheet-item-render";
+
+gx-action-sheet-item {
+  @include visibility(block);
+}

--- a/src/components/action-sheet-item/action-sheet-item.tsx
+++ b/src/components/action-sheet-item/action-sheet-item.tsx
@@ -1,0 +1,58 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Prop,
+  h
+} from "@stencil/core";
+import { IClickableComponent, IComponent } from "../common/interfaces";
+import { ActionSheetItemRender } from "../renders/bootstrap/action-sheet-item/action-sheet-item-render";
+
+@Component({
+  shadow: false,
+  styleUrl: "action-sheet-item.scss",
+  tag: "gx-action-sheet-item"
+})
+export class ActionSheetItem implements IClickableComponent, IComponent {
+  constructor() {
+    this.renderer = new ActionSheetItemRender(this);
+  }
+
+  private renderer: ActionSheetItemRender;
+  @Element() element: HTMLGxActionSheetItemElement;
+
+  /**
+   * This attribute lets you specify the type of action. `"cancel"` and `"destructive"` are style differently
+   */
+  @Prop() actionType: "cancel" | "default" | "destructive" = "default";
+
+  /**
+   * This attribute lets you specify if the element is disabled.
+   * If disabled, it will not fire any user interaction related event
+   * (for example, click event).
+   */
+  @Prop() disabled = false;
+
+  /**
+   * Fired when the action sheet item is clicked
+   */
+  @Event() onClick: EventEmitter;
+
+  handleClick(event: UIEvent) {
+    if (this.disabled) {
+      return;
+    }
+
+    this.onClick.emit(event);
+    event.preventDefault();
+  }
+
+  componentDidLoad() {
+    this.renderer.componentDidLoad();
+  }
+
+  render() {
+    return this.renderer.render({ default: <slot /> });
+  }
+}

--- a/src/components/action-sheet-item/readme.md
+++ b/src/components/action-sheet-item/readme.md
@@ -1,0 +1,32 @@
+# gx-action-sheet-item
+
+This component allows showing an action in a `gx-action-sheet` component.
+
+```
+<gx-action-sheet>
+    <gx-action-sheet-item action-type="destructive">Delete</gx-action-sheet-item>
+    <gx-action-sheet-item>Share</gx-action-sheet-item>
+    <gx-action-sheet-item>Play</gx-action-sheet-item>
+    <gx-action-sheet-item>Favorite</gx-action-sheet-item>
+    <gx-action-sheet-item action-type="cancel">Favorite</gx-action-sheet-item>
+</gx-action-sheet>
+```
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property     | Attribute     | Description                                                                                                                                              | Type                                     | Default     |
+| ------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- | ----------- |
+| `actionType` | `action-type` | This attribute lets you specify the type of action. `"cancel"` and `"destructive"` are style differently                                                 | `"cancel" \| "default" \| "destructive"` | `"default"` |
+| `disabled`   | `disabled`    | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event). | `boolean`                                | `false`     |
+
+## Events
+
+| Event     | Description                                 | Type               |
+| --------- | ------------------------------------------- | ------------------ |
+| `onClick` | Fired when the action sheet item is clicked | `CustomEvent<any>` |
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/action-sheet/action-sheet.scss
+++ b/src/components/action-sheet/action-sheet.scss
@@ -1,0 +1,6 @@
+@import "../common/_base";
+@import "../renders/bootstrap/action-sheet/action-sheet-render";
+
+gx-action-sheet {
+  @include visibility(block);
+}

--- a/src/components/action-sheet/action-sheet.tsx
+++ b/src/components/action-sheet/action-sheet.tsx
@@ -1,0 +1,56 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  Listen,
+  Prop,
+  h
+} from "@stencil/core";
+import { IComponent } from "../common/interfaces";
+import { ActionSheetRender } from "../renders/bootstrap/action-sheet/action-sheet-render";
+
+@Component({
+  shadow: false,
+  styleUrl: "action-sheet.scss",
+  tag: "gx-action-sheet"
+})
+export class ActionSheet implements IComponent {
+  constructor() {
+    this.renderer = new ActionSheetRender(this);
+  }
+
+  private renderer: ActionSheetRender;
+
+  @Element() element: HTMLGxActionSheetElement;
+
+  /**
+   * This attribute lets you specify the label for the close button. Important for accessibility.
+   */
+  @Prop() closeButtonLabel: string;
+
+  /**
+   * This attribute lets you specify if the action sheet is opened or closed.
+   */
+  @Prop({ mutable: true })
+  opened = false;
+
+  /**
+   * Fired when the action sheet is closed
+   */
+  @Event() onClose: EventEmitter;
+
+  /**
+   * Fired when the action sheet is opened
+   */
+  @Event() onOpen: EventEmitter;
+
+  @Listen("onClick")
+  handleItemClick() {
+    this.opened = false;
+  }
+
+  render() {
+    return this.renderer.render({ default: <slot /> });
+  }
+}

--- a/src/components/action-sheet/readme.md
+++ b/src/components/action-sheet/readme.md
@@ -1,0 +1,41 @@
+# gx-action-sheet
+
+This component allows showing a modal dialog containing a set of actions (`gx-action-sheet-item` elements). When an action is clicked, the dialog is closed. It can be dismissed using the close button.
+
+```
+<gx-action-sheet>
+    <gx-action-sheet-item action-type="destructive">Delete</gx-action-sheet-item>
+    <gx-action-sheet-item>Share</gx-action-sheet-item>
+    <gx-action-sheet-item>Play</gx-action-sheet-item>
+    <gx-action-sheet-item>Favorite</gx-action-sheet-item>
+    <gx-action-sheet-item action-type="cancel">Favorite</gx-action-sheet-item>
+</gx-action-sheet>
+```
+
+## Children
+
+It accepts `gx-action-sheet-item` as its child elements.
+
+## Styling with SASS
+
+A SASS mixin called `gx-action-sheet` is provided in `theming/theming-mixins.scss` to ease the styling of this element. See the theming [mixins documentation](/sassdoc/theming-mixins.html.md) for more information.
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property           | Attribute            | Description                                                                                  | Type      | Default     |
+| ------------------ | -------------------- | -------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `closeButtonLabel` | `close-button-label` | This attribute lets you specify the label for the close button. Important for accessibility. | `string`  | `undefined` |
+| `opened`           | `opened`             | This attribute lets you specify if the action sheet is opened or closed.                     | `boolean` | `false`     |
+
+## Events
+
+| Event     | Description                           | Type               |
+| --------- | ------------------------------------- | ------------------ |
+| `onClose` | Fired when the action sheet is closed | `CustomEvent<any>` |
+| `onOpen`  | Fired when the action sheet is opened | `CustomEvent<any>` |
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -63,8 +63,10 @@ export class Modal implements IComponent {
 
     if (newValue) {
       this.renderer.open();
+      this.onOpen.emit();
     } else {
       this.renderer.close();
+      this.onClose.emit();
     }
   }
 

--- a/src/components/renders/bootstrap/action-sheet-item/action-sheet-item-render.e2e.ts
+++ b/src/components/renders/bootstrap/action-sheet-item/action-sheet-item-render.e2e.ts
@@ -1,0 +1,40 @@
+import { E2EPage, newE2EPage } from "@stencil/core/testing";
+
+describe("gx-action-sheet-item", () => {
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+    <gx-action-sheet opened="true">
+      <gx-action-sheet-item action-type="destructive">Delete</gx-action-sheet-item>
+      <gx-action-sheet-item>Share</gx-action-sheet-item>
+      <gx-action-sheet-item disabled>Play</gx-action-sheet-item>
+      <gx-action-sheet-item>Favorite</gx-action-sheet-item>
+      <gx-action-sheet-item action-type="cancel">Cancel</gx-action-sheet-item>
+    </gx-action-sheet>
+    `);
+  });
+
+  it("should have list group classes", async () => {
+    const actionItem = await page.find("gx-action-sheet-item");
+    expect(actionItem.className.indexOf("list-group-item")).toBeGreaterThan(-1);
+    expect(
+      actionItem.className.indexOf("list-group-item-action")
+    ).toBeGreaterThan(-1);
+  });
+
+  it("should render disabled actions", async () => {
+    const disabledAction = await page.find("gx-action-sheet-item[disabled]");
+    expect(disabledAction.className.indexOf("disabled")).toBeGreaterThan(-1);
+  });
+
+  it("should render destructive actions", async () => {
+    const destructiveAction = await page.find(
+      "gx-action-sheet-item[action-type='destructive']"
+    );
+    expect(destructiveAction.className.indexOf("text-danger")).toBeGreaterThan(
+      -1
+    );
+  });
+});

--- a/src/components/renders/bootstrap/action-sheet-item/action-sheet-item-render.scss
+++ b/src/components/renders/bootstrap/action-sheet-item/action-sheet-item-render.scss
@@ -1,0 +1,5 @@
+gx-action-sheet-item {
+  &:not([disabled]) {
+    cursor: pointer;
+  }
+}

--- a/src/components/renders/bootstrap/action-sheet-item/action-sheet-item-render.tsx
+++ b/src/components/renders/bootstrap/action-sheet-item/action-sheet-item-render.tsx
@@ -1,0 +1,30 @@
+import { h } from "@stencil/core";
+import { IRenderer } from "../../../common/interfaces";
+import { ActionSheetItem } from "../../../action-sheet-item/action-sheet-item";
+
+export class ActionSheetItemRender implements IRenderer {
+  constructor(public component: ActionSheetItem) {}
+
+  componentDidLoad() {
+    const actionSheetItem = this.component;
+    const classes = ["list-group-item", "list-group-item-action"];
+
+    if (actionSheetItem.actionType === "destructive") {
+      classes.push("text-danger");
+    }
+
+    if (actionSheetItem.disabled) {
+      classes.push("disabled");
+    }
+
+    actionSheetItem.element.classList.add(...classes);
+
+    actionSheetItem.element.addEventListener("click", e =>
+      actionSheetItem.handleClick(e)
+    );
+  }
+
+  render(slots: { default }) {
+    return [<gx-bootstrap />, slots.default];
+  }
+}

--- a/src/components/renders/bootstrap/action-sheet/_action-sheet-theming-mixins.scss
+++ b/src/components/renders/bootstrap/action-sheet/_action-sheet-theming-mixins.scss
@@ -1,0 +1,11 @@
+////
+/// @group theming-mixins
+////
+
+/// Helper mixin to ease styling gx-action-sheet custom elements
+/// @param {string} $class Base class of the component
+@mixin gx-action-sheet($class) {
+  & {
+    @extend #{$class} !optional;
+  }
+}

--- a/src/components/renders/bootstrap/action-sheet/action-sheet-render.e2e.ts
+++ b/src/components/renders/bootstrap/action-sheet/action-sheet-render.e2e.ts
@@ -1,0 +1,61 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+const CLOSE_BUTTON_LABEL = "Close me!";
+
+describe("gx-action-sheet", () => {
+  let element: E2EElement;
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+    <gx-action-sheet opened="true" close-button-label="${CLOSE_BUTTON_LABEL}">
+      <gx-action-sheet-item action-type="destructive">Delete</gx-action-sheet-item>
+      <gx-action-sheet-item>Share</gx-action-sheet-item>
+      <gx-action-sheet-item disabled>Play</gx-action-sheet-item>
+      <gx-action-sheet-item>Favorite</gx-action-sheet-item>
+      <gx-action-sheet-item action-type="cancel">Cancel</gx-action-sheet-item>
+    </gx-action-sheet>
+    `);
+    element = await page.find("gx-action-sheet");
+  });
+
+  it("should render all actions", async () => {
+    const actions = await element.findAll("gx-action-sheet-item");
+    expect(actions.length).toBe(5);
+
+    expect(actions[0].textContent).toBe("Delete");
+    expect(actions[1].textContent).toBe("Share");
+    expect(actions[2].textContent).toBe("Play");
+    expect(actions[3].textContent).toBe("Favorite");
+    expect(actions[4].textContent).toBe("Cancel");
+  });
+
+  it("should set the close action label", async () => {
+    const modal = await element.find("gx-modal");
+    expect(await modal.getProperty("closeButtonLabel")).toBe(
+      CLOSE_BUTTON_LABEL
+    );
+  });
+
+  it("should use list group classes", async () => {
+    const listGroup = await element.find(".list-group");
+    expect(listGroup).toBeDefined();
+    expect(listGroup.classList.contains("list-group-flush")).toBe(true);
+  });
+
+  it("should fire the onClose and onOpen events", async () => {
+    const spyOnClose = await element.spyOnEvent("onClose");
+    const modal = await element.find("gx-modal");
+    await modal.setProperty("opened", false);
+    await page.waitForChanges();
+
+    expect(spyOnClose).toHaveReceivedEvent();
+
+    const spyOnOpen = await element.spyOnEvent("onOpen");
+    await modal.setProperty("opened", true);
+    await page.waitForChanges();
+
+    expect(spyOnOpen).toHaveReceivedEvent();
+  });
+});

--- a/src/components/renders/bootstrap/action-sheet/action-sheet-render.scss
+++ b/src/components/renders/bootstrap/action-sheet/action-sheet-render.scss
@@ -1,0 +1,5 @@
+gx-action-sheet {
+  .modal-body {
+    padding: 0;
+  }
+}

--- a/src/components/renders/bootstrap/action-sheet/action-sheet-render.tsx
+++ b/src/components/renders/bootstrap/action-sheet/action-sheet-render.tsx
@@ -1,0 +1,35 @@
+import { h } from "@stencil/core";
+import { IRenderer } from "../../../common/interfaces";
+import { ActionSheet } from "../../../action-sheet/action-sheet";
+
+export class ActionSheetRender implements IRenderer {
+  constructor(public component: ActionSheet) {}
+
+  private handleOnClose(e: CustomEvent) {
+    this.component.opened = false;
+    this.component.onClose.emit(e);
+  }
+
+  private handleOnOpen(e: CustomEvent) {
+    this.component.opened = true;
+    this.component.onOpen.emit(e);
+  }
+
+  render(slots: { default }) {
+    const actionSheet = this.component;
+
+    return [
+      <gx-bootstrap />,
+      <gx-modal
+        opened={actionSheet.opened}
+        closeButtonLabel={actionSheet.closeButtonLabel}
+        onOnClose={this.handleOnClose.bind(this)}
+        onOnOpen={this.handleOnOpen.bind(this)}
+      >
+        <div slot="body">
+          <div class="list-group list-group-flush">{slots.default}</div>
+        </div>
+      </gx-modal>
+    ];
+  }
+}

--- a/src/components/renders/bootstrap/modal/modal-render.tsx
+++ b/src/components/renders/bootstrap/modal/modal-render.tsx
@@ -16,13 +16,11 @@ export class ModalRender implements IRenderer {
   componentDidLoad() {
     const modalElement = this.getModalElement();
 
-    modalElement.addEventListener("show.bs.modal", e => {
-      this.component.onOpen.emit(e);
+    modalElement.addEventListener("show.bs.modal", () => {
       this.component.opened = true;
     });
 
-    modalElement.addEventListener("hide.bs.modal", e => {
-      this.component.onClose.emit(e);
+    modalElement.addEventListener("hide.bs.modal", () => {
       this.component.opened = false;
     });
 


### PR DESCRIPTION
New component gx-action-sheet allows showing a dialog with a set of actions for the user to choose.
When an action is clicked, the dialog is closed.

To render the dialog a `gx-modal` component is used.
To show the available actions, a `gx-action-sheet-item` component (also created in this PR) is used.
Action items have semantic through the `action-type` attribute, that affect the way the action is displayed. Currently the supported action types are `destructive`, `cancel` and `default`.
