### PR TITLE
Collapse navbar when an gx-navbar-link is clicked

### DIFF
--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Prop, h } from "@stencil/core";
+import { Component, Element, Listen, Prop, h } from "@stencil/core";
 import { NavBarRender } from "../renders/bootstrap/navbar/navbar-render";
 import { IComponent, IVisibilityComponent } from "../common/interfaces";
 
@@ -50,6 +50,12 @@ export class NavBar implements IComponent, IVisibilityComponent {
    * | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
    */
   @Prop() invisibleMode: "collapse" | "keep-space" = "collapse";
+
+  @Listen("click")
+  handleClick(e: UIEvent) {
+    const target = e.target as HTMLElement;
+    this.renderer.handleItemClick(target);
+  }
 
   render() {
     return this.renderer.render({

--- a/src/components/renders/bootstrap/navbar/navbar-render.tsx
+++ b/src/components/renders/bootstrap/navbar/navbar-render.tsx
@@ -79,6 +79,15 @@ export class NavBarRender implements IRenderer {
     this.transitioning = false;
   }
 
+  handleItemClick(targetElement: HTMLElement) {
+    if (targetElement.matches("gx-navbar-link a")) {
+      const collapseElement = this.component.element.querySelector(
+        ".navbar-collapse"
+      ) as HTMLElement;
+      this.collapse(collapseElement);
+    }
+  }
+
   render(slots: { default; header }) {
     if (!this.navBarId) {
       this.navBarId = this.component.id


### PR DESCRIPTION
Auto-collapse the navbar when a `gx-navbar-link` element is clicked (when expanded using the burger menu).
