### PR TITLE
Fix Exception for gx-select when readonly.

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -986,6 +986,20 @@ export namespace Components {
      */
     invisibleMode: "collapse" | "keep-space";
   }
+  interface GxVideo {
+    /**
+     * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+     */
+    disabled: boolean;
+    /**
+     * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
+     */
+    invisibleMode: "collapse" | "keep-space";
+    /**
+     * This attribute is for specifies the src of the video.
+     */
+    src: string;
+  }
 }
 
 declare global {
@@ -1284,6 +1298,12 @@ declare global {
     prototype: HTMLGxTextblockElement;
     new (): HTMLGxTextblockElement;
   };
+
+  interface HTMLGxVideoElement extends Components.GxVideo, HTMLStencilElement {}
+  var HTMLGxVideoElement: {
+    prototype: HTMLGxVideoElement;
+    new (): HTMLGxVideoElement;
+  };
   interface HTMLElementTagNameMap {
     "gx-action-sheet": HTMLGxActionSheetElement;
     "gx-action-sheet-item": HTMLGxActionSheetItemElement;
@@ -1324,6 +1344,7 @@ declare global {
     "gx-table": HTMLGxTableElement;
     "gx-table-cell": HTMLGxTableCellElement;
     "gx-textblock": HTMLGxTextblockElement;
+    "gx-video": HTMLGxVideoElement;
   }
 }
 
@@ -2471,6 +2492,24 @@ declare namespace LocalJSX {
      */
     onOnClick?: (event: CustomEvent<any>) => void;
   }
+  interface GxVideo extends JSXBase.HTMLAttributes<HTMLGxVideoElement> {
+    /**
+     * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+     */
+    disabled?: boolean;
+    /**
+     * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
+     */
+    invisibleMode?: "collapse" | "keep-space";
+    /**
+     * Emitted when the element is clicked.
+     */
+    onOnClick?: (event: CustomEvent<any>) => void;
+    /**
+     * This attribute is for specifies the src of the video.
+     */
+    src?: string;
+  }
 
   interface IntrinsicElements {
     "gx-action-sheet": GxActionSheet;
@@ -2512,6 +2551,7 @@ declare namespace LocalJSX {
     "gx-table": GxTable;
     "gx-table-cell": GxTableCell;
     "gx-textblock": GxTextblock;
+    "gx-video": GxVideo;
   }
 }
 

--- a/src/components/common/interfaces.ts
+++ b/src/components/common/interfaces.ts
@@ -25,6 +25,10 @@ export interface IFormComponent
   handleChange: (UIEvent) => void;
   id: string;
   input: EventEmitter;
+  /**
+   * Returns the DOM Control Id of the "labelable" element inside the component. This Id will be used for <label> 'for' attribute.
+   * Labelable elements are: button, input (if the type attribute is not in the Hidden state) progress, select, textarea, form-associated custom elements
+   */
   getNativeInputId: () => void;
 }
 

--- a/src/components/renders/bootstrap/form-field/form-field-render.tsx
+++ b/src/components/renders/bootstrap/form-field/form-field-render.tsx
@@ -64,13 +64,17 @@ export class FormFieldRender implements IRenderer {
     const innerControl: any = formField.element.querySelector("[area='field']");
     if (innerControl && innerControl.getNativeInputId) {
       const nativeInputId = await innerControl.getNativeInputId();
-      const nativeInput = formField.element.querySelector(`#${nativeInputId}`);
-      if (nativeInput) {
-        nativeInput.setAttribute("data-part", "field");
-      }
-      const innerLabel: any = formField.element.querySelector("label");
-      if (nativeInputId && innerLabel) {
-        innerLabel.setAttribute("for", nativeInputId);
+      if (nativeInputId) {
+        const nativeInput = formField.element.querySelector(
+          `#${nativeInputId}`
+        );
+        if (nativeInput) {
+          nativeInput.setAttribute("data-part", "field");
+        }
+        const innerLabel: any = formField.element.querySelector("label");
+        if (nativeInputId && innerLabel) {
+          innerLabel.setAttribute("for", nativeInputId);
+        }
       }
     }
   }

--- a/src/components/renders/bootstrap/select/select-render.tsx
+++ b/src/components/renders/bootstrap/select/select-render.tsx
@@ -3,11 +3,16 @@ import { IRenderer } from "../../../common/interfaces";
 import { Select } from "../../../select/select";
 
 export class SelectRender implements IRenderer {
-  constructor(public component: Select) {}
+  constructor(public component: Select) {
+    if (!this.selectId && !this.component.readonly) {
+      this.selectId = this.component.id
+        ? `${this.component.id}__select`
+        : `gx-select-auto-id-${autoSelectId++}`;
+    }
+  }
 
   protected options: any[] = [];
   protected element: HTMLElement;
-  protected nativeSelect: HTMLSelectElement;
   private selectId: string;
 
   updateOptions(options) {
@@ -15,8 +20,11 @@ export class SelectRender implements IRenderer {
   }
 
   getNativeInputId() {
-    return this.nativeSelect.id;
+    return !this.component.readonly ? this.selectId : null;
   }
+
+  /* tslint:disable-next-line:no-empty */
+  componentDidUnload() {}
 
   private getCssClasses() {
     const classList = [];
@@ -53,17 +61,7 @@ export class SelectRender implements IRenderer {
     this.component.input.emit(event);
   }
 
-  componentDidUnload() {
-    this.nativeSelect = null;
-  }
-
   render() {
-    if (!this.selectId) {
-      this.selectId = this.component.id
-        ? `${this.component.id}__select`
-        : `gx-select-auto-id-${autoSelectId++}`;
-    }
-
     if (this.component.readonly) {
       return (
         <span class={this.getCssClasses()}>
@@ -79,7 +77,6 @@ export class SelectRender implements IRenderer {
         onChange: this.handleChange.bind(this),
         ref: (select: HTMLSelectElement) => {
           select.value = this.component.value;
-          this.nativeSelect = select;
         }
       };
 


### PR DESCRIPTION
getNativeInputId method must only return the id of "labelable" elements:
- button, input (if the type attribute is not in the Hidden state)meter, output, progress, select, textarea, form-associated custom elements