### PR TITLE
Stretch images to fit parent

### DIFF
--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -5,8 +5,8 @@ gx-image {
 
   @include visibility(inline-flex);
 
-  justify-content: center;
-  align-items: center;
+  justify-content: stretch;
+  align-items: stretch;
   flex: 1;
 
   & > img {


### PR DESCRIPTION
Following GeneXus criteria, images stretch to fit their parent container.