### PR TITLE
Fix scrollbars shown inside gx-image components when lazy loaded

### DIFF
--- a/src/components/image/image.e2e.ts
+++ b/src/components/image/image.e2e.ts
@@ -13,18 +13,19 @@ describe("gx-image", () => {
   });
 
   it("inner img should have alternate text", async () => {
-    const img = await page.find("img");
+    const img = await element.find("img");
     expect(await img.getProperty("alt")).toEqual(
       await element.getProperty("alt")
     );
   });
 
   it("should lazy load the image", async () => {
-    const img = await page.find("img");
+    const img = await element.find("img");
     const className: string = await img.getProperty("className");
     expect(className.includes("gx-lazyload")).toBe(true);
     expect(await img.getAttribute("src")).toBeNull();
     expect(await img.getAttribute("data-src")).toBe("img.png");
+    expect(await element.classList.contains("gx-img-lazyloading")).toBe(true);
   });
 
   it("should load the image", async () => {
@@ -34,6 +35,7 @@ describe("gx-image", () => {
     const className: string = await img.getProperty("className");
     expect(className.includes("gx-lazyload")).toBe(false);
     expect(await img.getAttribute("src")).toBe("img.png");
+    expect(await element.classList.contains("gx-img-lazyloading")).toBe(false);
   });
 
   it("should set the inner image class", async () => {

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -9,6 +9,10 @@ gx-image {
   align-items: stretch;
   flex: 1;
 
+  &.gx-img-lazyloading {
+    overflow: hidden;
+  }
+
   & > img {
     @include elevation();
     margin-top: var(--margin-top);

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -40,6 +40,9 @@ export class Image
     ]);
 
     this.handleClick = this.handleClick.bind(this);
+
+    this.handleLazyLoaded = this.handleLazyLoaded.bind(this);
+    document.addEventListener("lazyloaded", this.handleLazyLoaded);
   }
 
   @Element() element: HTMLGxImageElement;
@@ -122,6 +125,10 @@ export class Image
     event.preventDefault();
   }
 
+  componentDidUnload() {
+    document.removeEventListener("lazyloaded", this.handleLazyLoaded);
+  }
+
   render() {
     const shouldLazyLoad = this.shouldLazyLoad();
 
@@ -146,7 +153,7 @@ export class Image
       />,
       <span />
     ];
-    return <Host>{body}</Host>;
+    return <Host class={{ "gx-img-lazyloading": shouldLazyLoad }}>{body}</Host>;
   }
 
   private shouldLazyLoad(): boolean {
@@ -156,6 +163,13 @@ export class Image
 
     const img: HTMLImageElement = this.element.querySelector("img");
     return img === null || img.classList.contains(LAZY_LOAD_CLASS);
+  }
+
+  private handleLazyLoaded(event: CustomEvent) {
+    const img: HTMLImageElement = this.element.querySelector("img");
+    if (event.target === img) {
+      this.element.classList.remove("gx-img-lazyloading");
+    }
   }
 }
 


### PR DESCRIPTION
Fixed an issue with `gx-image`, where the component's size was smaller than the loading feedback image, scrollbars were shown.

A class is added to the `gx-image` component while it's being lazy loaded, to turn off scrollbars. After the image is loaded, the class is removed.
