### PR TITLE
Inherit font size and weight for h1, h2 and footer inside gx-edit

### DIFF
--- a/src/components/renders/bootstrap/edit/edit-render.scss
+++ b/src/components/renders/bootstrap/edit/edit-render.scss
@@ -32,6 +32,13 @@ gx-edit {
     padding: 0;
     line-height: 1.2;
   }
+
+  h1,
+  h2,
+  footer {
+    font-size: inherit;
+    font-weight: inherit;
+  }
 }
 
 gx-table-cell {


### PR DESCRIPTION
When `font-category` was set to `headline`, `subheadline` or `footnote` the default Bootstrap `font-size` and `font-weight` was used for `h1`, `h2` and `footer` elements.

Now, these properties are set to inherit.

