### PR TITLE
Don't render gx-image when src property is empty

### DIFF
--- a/src/components/image/image.e2e.ts
+++ b/src/components/image/image.e2e.ts
@@ -52,4 +52,15 @@ describe("gx-image", () => {
     await img.click();
     expect(spy).toHaveReceivedEvent();
   });
+
+  it("should not render when src is empty", async () => {
+    let isHidden = await element.getProperty("hidden");
+    expect(isHidden).toBe(false);
+
+    await element.setAttribute("src", "");
+    await page.waitForChanges();
+    isHidden = await element.getProperty("hidden");
+
+    expect(isHidden).toBe(true);
+  });
 });

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -132,28 +132,37 @@ export class Image
   render() {
     const shouldLazyLoad = this.shouldLazyLoad();
 
-    const body = [
-      <img
-        class={{
-          [LAZY_LOAD_CLASS]: shouldLazyLoad,
-          [this.cssClass]: this.cssClass !== "",
-          "gx-image-tile": this.scaleType === "tile"
-        }}
-        style={
-          this.scaleType === "tile"
-            ? { backgroundImage: `url(${this.src})` }
-            : { objectFit: this.scaleType }
-        }
-        onClick={this.handleClick}
-        data-src={shouldLazyLoad ? this.src : undefined}
-        src={!shouldLazyLoad ? this.src : undefined}
-        alt={this.alt}
-        width={this.width}
-        height={this.height}
-      />,
-      <span />
-    ];
-    return <Host class={{ "gx-img-lazyloading": shouldLazyLoad }}>{body}</Host>;
+    const body = this.src
+      ? [
+          <img
+            class={{
+              [LAZY_LOAD_CLASS]: shouldLazyLoad,
+              [this.cssClass]: this.cssClass !== "",
+              "gx-image-tile": this.scaleType === "tile"
+            }}
+            style={
+              this.scaleType === "tile"
+                ? { backgroundImage: `url(${this.src})` }
+                : { objectFit: this.scaleType }
+            }
+            onClick={this.handleClick}
+            data-src={shouldLazyLoad ? this.src : undefined}
+            src={!shouldLazyLoad ? this.src : undefined}
+            alt={this.alt}
+            width={this.width}
+            height={this.height}
+          />,
+          <span />
+        ]
+      : [];
+    return (
+      <Host
+        class={{ "gx-img-lazyloading": shouldLazyLoad }}
+        aria-hidden={!this.src}
+      >
+        {body}
+      </Host>
+    );
   }
 
   private shouldLazyLoad(): boolean {

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -155,11 +155,9 @@ export class Image
           <span />
         ]
       : [];
+
     return (
-      <Host
-        class={{ "gx-img-lazyloading": shouldLazyLoad }}
-        aria-hidden={!this.src}
-      >
+      <Host class={{ "gx-img-lazyloading": shouldLazyLoad }} hidden={!this.src}>
         {body}
       </Host>
     );


### PR DESCRIPTION
If `src` property is empty, we don't render it, following the GeneXus criteria in SD generators.
