### PR TITLE
Input event was passing 'on' as value

### DIFF
--- a/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
+++ b/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
@@ -76,7 +76,14 @@ export class CheckBoxRender implements Renderer {
     return [
       <gx-bootstrap />,
       <div class="custom-control custom-checkbox">
-        <input {...attris} type="checkbox" checked={checkbox.checked} />
+        <input
+          {...attris}
+          type="checkbox"
+          checked={checkbox.checked}
+          value={
+            checkbox.checked ? checkbox.checkedValue : checkbox.unCheckedValue
+          }
+        />
         <label
           class="custom-control-label"
           {...forAttris}

--- a/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
+++ b/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
@@ -66,7 +66,7 @@ export class CheckBoxRender implements Renderer {
       "data-native-element": "",
       disabled: checkbox.disabled,
       id: this.inputId,
-      onChange: this.handleChange
+      onInput: this.handleChange
     };
 
     const forAttris = {

--- a/src/components/renders/bootstrap/checkbox/checkbox.e2e.ts
+++ b/src/components/renders/bootstrap/checkbox/checkbox.e2e.ts
@@ -33,13 +33,20 @@ describe("gx-checkbox", () => {
   });
 
   it("fires input event", async () => {
-    await element.setProperty("checkedValue", "yes");
-    await element.setProperty("unCheckedValue", "no");
+    const uncheckedValue = "no";
+    const checkedValue = "yes";
+    await element.setProperty("checkedValue", checkedValue);
+    await element.setProperty("unCheckedValue", uncheckedValue);
     await page.waitForChanges();
     const spy = await element.spyOnEvent("input");
     const input = await page.find("input");
+
     await input.click();
     expect(spy).toHaveReceivedEvent();
-    expect(await element.getProperty("value")).toBe("no");
+    expect(await element.getProperty("value")).toBe(uncheckedValue);
+
+    await input.click();
+    expect(spy).toHaveReceivedEvent();
+    expect(await element.getProperty("value")).toBe(checkedValue);
   });
 });

--- a/src/components/renders/bootstrap/checkbox/checkbox.e2e.ts
+++ b/src/components/renders/bootstrap/checkbox/checkbox.e2e.ts
@@ -31,4 +31,15 @@ describe("gx-checkbox", () => {
     await page.waitForChanges();
     expect(await input.getProperty("checked")).toEqual(false);
   });
+
+  it("fires input event", async () => {
+    await element.setProperty("checkedValue", "yes");
+    await element.setProperty("unCheckedValue", "no");
+    await page.waitForChanges();
+    const spy = await element.spyOnEvent("input");
+    const input = await page.find("input");
+    await input.click();
+    expect(spy).toHaveReceivedEvent();
+    expect(await element.getProperty("value")).toBe("no");
+  });
 });


### PR DESCRIPTION
When the `input` event was fired, the value passed to the event handler was `"on"`  (the default value for inputs of type checkbox), instead of the value of the `checkedValue` or `unCheckedValue` properties

