### PR TITLE
Fix image sizing issues when inside an aligned container

### DIFF
--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -68,6 +68,34 @@ gx-image {
   }
 }
 
+[align="center"] {
+  & > gx-image {
+    justify-self: stretch;
+    justify-content: center;
+  }
+}
+
+[align="right"] {
+  & > gx-image {
+    justify-self: stretch;
+    justify-content: flex-end;
+  }
+}
+
+[valign="middle"] {
+  & > gx-image {
+    align-self: stretch;
+    align-items: center;
+  }
+}
+
+[valign="bottom"] {
+  & > gx-image {
+    align-self: stretch;
+    align-items: flex-end;
+  }
+}
+
 @keyframes gx-image-loading {
   0% {
     -webkit-transform: rotate(0deg);


### PR DESCRIPTION
When a `gx-image` was inside an aligned container (for example, `gx-table-cell`), it wouldn't size correctly and would overflow.
