### PR TITLE
Fix images alignment not working

### DIFF
--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -10,6 +10,9 @@ gx-image {
   flex: 1;
 
   &.gx-img-no-auto-grow {
+    width: var(--width);
+    height: var(--height);
+
     position: relative;
 
     & > img {
@@ -25,6 +28,9 @@ gx-image {
 
   &:not(.gx-img-no-auto-grow) {
     & > img {
+      width: var(--width);
+      height: var(--height);
+
       max-height: calc(
         100% - var(--margin-top, 0px) - var(--margin-bottom, 0px)
       );


### PR DESCRIPTION
`gx-image` components inside `gx-table-cell` wouldn't align when `auto-grow=false`.
Width and height are now specified using `--width` and `--height` CSS variables.
