### PR TITLE
Fix to image control: removed setting that hides when there is no src

### DIFF
--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -174,7 +174,6 @@ export class Image
           "gx-img-lazyloading": shouldLazyLoad,
           "gx-img-no-auto-grow": !this.autoGrow
         }}
-        hidden={!this.src}
         style={{
           width: this.width
             ? `calc(${this.width} + var(--margin-left, 0px) + var(--margin-right, 0px))`


### PR DESCRIPTION
Removed setting that hides the control when there is no src, because it conflicts with hidden setting in Angular when it loads for the first time.