### PR TITLE
Fix image alignment when auto grow is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 www/
 loader/
+.stencil/
 
 *~
 *.sw[mnpcod]

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "scss-bundle.watch": "scss-bundle -w ./src/components -e ./src/components/_components-theming-mixins.scss -o dist/theming/theming-mixins.scss",
     "start": "stencil build --dev --watch --serve",
     "start.es5": "stencil build --dev --watch --serve --es5",
-    "test": "stencil test --spec --e2e",
-    "test.ci": "stencil test --spec",
-    "test.watch": "stencil test --spec --e2e --watchAll",
+    "test": "stencil test --spec --e2e --screenshot",
+    "test.ci": "stencil test --spec --screenshot",
+    "test.watch": "stencil test --spec --e2e --watchAll --screenshot",
     "validate": "npm run lint && npm run test && npm run build && npm run scss-bundle",
     "validate.ci": "npm run lint && npm run test.ci && npm run build --max-workers 1 --debug && npm run scss-bundle"
   },

--- a/screenshot/.gitignore
+++ b/screenshot/.gitignore
@@ -1,0 +1,3 @@
+images
+builds
+compare.html

--- a/src/components/image/image-align.e2e.ts
+++ b/src/components/image/image-align.e2e.ts
@@ -1,0 +1,60 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+const testImage1 =
+  "data:image/x-icon;base64,AAABAAEAICAQAAEABADoAgAAFgAAACgAAAAgAAAAQAAAAAEABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYGyAAISAgAA4gMQAFKUkAATVlAABFhQAAUJgAAFamAABhuQAFZ8MACGzIAA1xzAATd9QAHYHbAAAAAAAAAAAAERERERERERERERERERERERERERERERERERERERERERERERFDERERERERERA0EREREREQWDAREREREREEpBERERERESq1IRERERECbHIREREREREFy2MREREQOLtRERERERERFKu4QhERJKu5QRERERERERKKqrUhE2yqpyEREREREREQXKqsgzi6qrURERERERERETuqqrqqqqmUEREREREREREouqqqqqqrchERERERERERBcqqqqqqrFERERERERERERO6qqqqqqkxERERERERERAmqqqqqqqqUhEREREREREEnKqqqqqqqshCERERERECbMqqqqqqqqqstSEREREQSdqqqqqqqqqqqr2EAREQJsyqqqqqqqqqqqqqzFIRJd3d3d3duqqqq93d3d3cUjdlVVVVVYuqqshVVVVVVnMRARERERBdqqvVARERERARERERERERO7u8kxEREREREREREREREQjbvXIREREREREREREREREF271RERERERERERERERERE8zKMRERERERERERERERERCN1yEREREREREREREREREQXdURERERERERERERERERET2zEREREREREREREREREREKghERERERERERERERERERFnERERERERERERERERERERMxEREREREREREREREREREREREREREREREAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
+describe("gx-image alignment", () => {
+  let tableCellElement: E2EElement;
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+  <gx-table
+    areas-template="'cell00' "
+    columns-template="100px"
+    rows-template="164px"
+    invisible-mode="keep-space"
+  >
+    <gx-table-cell
+      area="cell00"
+      overflow-mode="scroll"
+      style="border: 1px solid black;"
+    >
+      <gx-image
+        auto-grow="false"
+        src="${testImage1}"
+        alt="ctrlImage4"
+        invisible-mode="keep-space"
+        style="--image-scale-type: none;"
+      >
+      </gx-image>
+    </gx-table-cell>
+  </gx-table>
+`);
+    tableCellElement = await page.find("gx-table-cell");
+  });
+
+  it("default alignment", async () => {
+    const results = await page.compareScreenshot();
+    expect(results).toMatchScreenshot();
+  });
+
+  it("alignment combinations", async () => {
+    const hAlignValues = ["left", "center", "right"];
+    const vAlignValues = ["top", "middle", "bottom"];
+
+    for (const hAlign of hAlignValues) {
+      for (const vAlign of vAlignValues) {
+        tableCellElement.setAttribute("align", hAlign);
+        tableCellElement.setAttribute("valign", vAlign);
+        await page.waitForChanges();
+
+        const results = await page.compareScreenshot(
+          `halign: '${hAlign}' - valign: '${vAlign}'`
+        );
+        expect(results).toMatchScreenshot();
+      }
+    }
+  });
+});

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -27,6 +27,7 @@ gx-image {
       left: 0;
       height: 100%;
       width: 100%;
+      object-position: left top;
     }
   }
 
@@ -112,12 +113,6 @@ gx-image {
   & > gx-image {
     justify-self: stretch;
     justify-content: flex-end;
-
-    &.gx-img-no-auto-grow {
-      img {
-        left: unset;
-      }
-    }
   }
 }
 
@@ -132,14 +127,31 @@ gx-image {
   & > gx-image {
     align-self: stretch;
     align-items: flex-end;
+  }
+}
 
-    &.gx-img-no-auto-grow {
-      img {
-        top: unset;
+@mixin cellAlignmentNoAutoGrow($halign, $valign) {
+  $valignValue: if($valign == middle, center, $valign);
+  [align="#{$halign}"][valign="#{$valign}"] {
+    & > gx-image {
+      &.gx-img-no-auto-grow {
+        img {
+          object-position: $halign $valignValue;
+        }
       }
     }
   }
 }
+
+@include cellAlignmentNoAutoGrow(left, top);
+@include cellAlignmentNoAutoGrow(left, middle);
+@include cellAlignmentNoAutoGrow(left, bottom);
+@include cellAlignmentNoAutoGrow(center, top);
+@include cellAlignmentNoAutoGrow(center, middle);
+@include cellAlignmentNoAutoGrow(center, bottom);
+@include cellAlignmentNoAutoGrow(right, top);
+@include cellAlignmentNoAutoGrow(right, middle);
+@include cellAlignmentNoAutoGrow(right, bottom);
 
 @keyframes gx-image-loading {
   0% {

--- a/src/components/table-cell/table-cell.tsx
+++ b/src/components/table-cell/table-cell.tsx
@@ -19,7 +19,7 @@ export class TableCell implements GxComponent {
   /**
    * Defines the horizontal aligmnent of the content of the cell.
    */
-  @Prop() readonly align: "left" | "right" | "center" = "left";
+  @Prop({ reflect: true }) readonly align: "left" | "right" | "center" = "left";
 
   /**
    * This attribute defines how the control behaves when the content overflows.
@@ -48,7 +48,7 @@ export class TableCell implements GxComponent {
   /**
    * Defines the vertical aligmnent of the content of the cell.
    */
-  @Prop() readonly valign: "top" | "bottom" | "medium" = "top";
+  @Prop({ reflect: true }) readonly valign: "top" | "bottom" | "medium" = "top";
 
   private observer: MutationObserver;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fix alignment in images when auto-grow=false
- Add screenshot tests to test all the alignment combinations
- Reflect align and valign properties  to attributes in `gx-table-cell` as the alignment is achieved using CSS attribute selectors

#### Testing instructions

- Create a 1x1 a `gx-table` component
- Inside the `gx-table-cell` place an image using the `gx-image` component with `auto-grow="false"`
- Change the `gx-table-cell` `align` and `valign` attributes and verify the image is correctly aligned inside the table cell.
