### PR TITLE
Fix vertical alignment when size specified

### DIFF
--- a/src/components/image/image-align.e2e.ts
+++ b/src/components/image/image-align.e2e.ts
@@ -5,6 +5,7 @@ const testImage1 =
 
 describe("gx-image alignment", () => {
   let tableCellElement: E2EElement;
+  let imageElement: E2EElement;
   let page: E2EPage;
 
   beforeEach(async () => {
@@ -33,6 +34,7 @@ describe("gx-image alignment", () => {
   </gx-table>
 `);
     tableCellElement = await page.find("gx-table-cell");
+    imageElement = await page.find("gx-image");
   });
 
   it("default alignment", async () => {
@@ -40,7 +42,7 @@ describe("gx-image alignment", () => {
     expect(results).toMatchScreenshot();
   });
 
-  it("alignment combinations", async () => {
+  it("correctly aligns", async () => {
     const hAlignValues = ["left", "center", "right"];
     const vAlignValues = ["top", "middle", "bottom"];
 
@@ -56,5 +58,21 @@ describe("gx-image alignment", () => {
         expect(results).toMatchScreenshot();
       }
     }
+  });
+
+  it("unsets justify-self when width is specified", async () => {
+    tableCellElement.setAttribute("align", "center");
+    imageElement.setProperty("width", "40px");
+    await page.waitForChanges();
+    const computedStyle = await imageElement.getComputedStyle();
+    expect(computedStyle.justifySelf).toBe("auto");
+  });
+
+  it("unsets align-self when height is specified", async () => {
+    tableCellElement.setAttribute("valign", "middle");
+    imageElement.setProperty("height", "40px");
+    await page.waitForChanges();
+    const computedStyle = await imageElement.getComputedStyle();
+    expect(computedStyle.alignSelf).toBe("auto");
   });
 });

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -36,6 +36,14 @@ export class Image
       {
         cssVariableName: "--image-scale-type",
         propertyName: "scaleType"
+      },
+      {
+        cssVariableName: "--height",
+        propertyName: "height"
+      },
+      {
+        cssVariableName: "--width",
+        propertyName: "width"
       }
     ]);
 
@@ -168,6 +176,8 @@ export class Image
         ]
       : [];
 
+    const isHeightSpecified = !!this.height;
+    const isWidthSpecified = !!this.width;
     return (
       <Host
         class={{
@@ -176,11 +186,13 @@ export class Image
         }}
         hidden={!this.src}
         style={{
-          width: this.width
-            ? `calc(${this.width} + var(--margin-left, 0px) + var(--margin-right, 0px))`
-            : null,
-          height: this.height
+          alignSelf: isHeightSpecified ? "unset" : null,
+          justifySelf: isWidthSpecified ? "unset" : null,
+          height: isHeightSpecified
             ? `calc(${this.height} + var(--margin-top, 0px) + var(--margin-bottom, 0px))`
+            : null,
+          width: isWidthSpecified
+            ? `calc(${this.width} + var(--margin-left, 0px) + var(--margin-right, 0px))`
             : null
         }}
       >


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fix alignment in images when size is specified

#### Testing instructions

1. Create a 1x1 a gx-table component
2. Inside the gx-table-cell place an image using the gx-image component with `width` and/or `height` specified. This can be done using the component's properties or the `--height` and `--width` CSS variables.
3. Change the gx-table-cell align and valign attributes and verify the image is correctly aligned inside the table cell.
