### PR TITLE
Limit the size of images inside gx-tab-caption component

### DIFF
--- a/src/components/renders/bootstrap/tab-caption/tab-caption-render.e2e.ts
+++ b/src/components/renders/bootstrap/tab-caption/tab-caption-render.e2e.ts
@@ -1,5 +1,8 @@
 import { newE2EPage, E2EPage, E2EElement } from "@stencil/core/testing";
 
+const testImage1 =
+  "data:image/x-icon;base64,AAABAAEAICAQAAEABADoAgAAFgAAACgAAAAgAAAAQAAAAAEABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYGyAAISAgAA4gMQAFKUkAATVlAABFhQAAUJgAAFamAABhuQAFZ8MACGzIAA1xzAATd9QAHYHbAAAAAAAAAAAAERERERERERERERERERERERERERERERERERERERERERERERFDERERERERERA0EREREREQWDAREREREREEpBERERERESq1IRERERECbHIREREREREFy2MREREQOLtRERERERERFKu4QhERJKu5QRERERERERKKqrUhE2yqpyEREREREREQXKqsgzi6qrURERERERERETuqqrqqqqmUEREREREREREouqqqqqqrchERERERERERBcqqqqqqrFERERERERERERO6qqqqqqkxERERERERERAmqqqqqqqqUhEREREREREEnKqqqqqqqshCERERERECbMqqqqqqqqqstSEREREQSdqqqqqqqqqqqr2EAREQJsyqqqqqqqqqqqqqzFIRJd3d3d3duqqqq93d3d3cUjdlVVVVVYuqqshVVVVVVnMRARERERBdqqvVARERERARERERERERO7u8kxEREREREREREREREQjbvXIREREREREREREREREF271RERERERERERERERERE8zKMRERERERERERERERERCN1yEREREREREREREREREQXdURERERERERERERERERET2zEREREREREREREREREREKghERERERERERERERERERFnERERERERERERERERERERMxEREREREREREREREREREREREREREREREAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
 describe("gx-tab-page", () => {
   let page: E2EPage;
   let tabCaptionElement: E2EElement;
@@ -9,8 +12,8 @@ describe("gx-tab-page", () => {
     await page.setContent(`
 <gx-tab>
   <gx-tab-caption slot="caption" selected>
-    <img slot="main-image" />
-    <img slot="disabled-image"/>
+    <img slot="main-image" src="${testImage1}" />
+    <img slot="disabled-image" src="${testImage1}" />
     First tab
   </gx-tab-caption>
 
@@ -51,5 +54,36 @@ describe("gx-tab-page", () => {
         window.getComputedStyle(elem).getPropertyValue("display") !== "none"
       );
     });
+  }
+
+  it("limits the size of the main and disabled images to 1em", async () => {
+    const tabCaptionStyle = await tabCaptionElement.getComputedStyle();
+    const fontSize = tabCaptionStyle.getPropertyValue("font-size");
+
+    const mainImageSize = await getImageSize(
+      "gx-tab-caption img[slot='main-image']"
+    );
+    expect(mainImageSize.height).toBe(fontSize);
+    expect(mainImageSize.width).toBe(fontSize);
+
+    tabCaptionElement.setAttribute("selected", false);
+    await page.waitForChanges();
+
+    const disabledImageSize = await getImageSize(
+      "gx-tab-caption img[slot='disabled-image']"
+    );
+    expect(disabledImageSize.height).toBe(fontSize);
+    expect(disabledImageSize.width).toBe(fontSize);
+  });
+
+  async function getImageSize(
+    selector: string
+  ): Promise<{ height: string; width: string }> {
+    const element = await page.find(selector);
+    const style = await element.getComputedStyle();
+    return {
+      height: style.getPropertyValue("height"),
+      width: style.getPropertyValue("width")
+    };
   }
 });

--- a/src/components/tab-caption/tab-caption.scss
+++ b/src/components/tab-caption/tab-caption.scss
@@ -3,7 +3,14 @@
 @import "../renders/bootstrap/tab-caption/tab-caption-render";
 
 gx-tab-caption {
-  @include visibility(block);
+  @include visibility(flex);
 
   @include imagePosition("a", ".gx-tab-caption--unselected");
+
+  [slot="main-image"],
+  [slot="disabled-image"] {
+    max-height: 1em;
+    max-width: 1em;
+    object-fit: contain;
+  }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `max-width` and `max-height` of  the main and disabled images are set to `1em`. This prevents big images to break the UI of the tab page.
Also, `object-fit: contain` is used to maintain its aspect ratio.

#### Testing instructions

- Place a main and a disabled image inside a `gx-tab-page` component. The images must be bigger than 16x16 pixels.
- Verify that the images have the same size in pixels as the font size of the text of the tab caption.
