### PR TITLE
Fix text overflowing when image behind

### DIFF
--- a/src/components/common/_image-position.scss
+++ b/src/components/common/_image-position.scss
@@ -40,8 +40,11 @@
     & > #{$imgParent} {
       flex-direction: column;
 
-      & > span {
+      & > img {
         position: absolute;
+      }
+      & > span {
+        z-index: 1;
       }
     }
   }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes text inside `gx-tab-caption` component overflowing when `image-position="behind"`.
Before:
![image](https://user-images.githubusercontent.com/5444806/81122638-ac828780-8f07-11ea-9e84-46e60f41f3ca.png)

After:
![image](https://user-images.githubusercontent.com/5444806/81122732-f23f5000-8f07-11ea-97dd-62b679149ced.png)


#### Testing instructions

1. Add a `gx-tab-caption` with a text and a main image.
2. Set `image-position="behind"`
3. Verify that the text doesn't overflow
