### PR TITLE
Add theming mixin for grid rows

### DIFF
--- a/src/components/grid-base/grid-base-theming-mixins.scss
+++ b/src/components/grid-base/grid-base-theming-mixins.scss
@@ -47,3 +47,17 @@
     }
   }
 }
+
+/// Helper mixin to ease styling gx-grid-base's custom elements rows
+/// @param {string} $class Base class of the component
+/// @param {string} $highlighted Class to be used when the grid row is active
+@mixin gx-grid-base-row($class, $highlighted: null) {
+  @extend #{$class};
+
+  @if ($highlighted != null) {
+    &:active,
+    &[data-gx-grid-highlighted] {
+      @extend #{$highlighted} !optional;
+    }
+  }
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Added theming mixin for styling grid rows.
For "highlighted" rows it uses both the `:active` pseudo class and a data attribute (`data-gx-grid-highlighted`).
