### PR TITLE
Fix label height in vertical form fields

### DIFF
--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -79,7 +79,7 @@ gx-form-field {
   .field-label-bottom {
     position: relative;
     width: 100%;
-    flex: 0 0 100%;
+    flex: 1;
     max-width: 100%;
   }
 

--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -75,12 +75,22 @@ gx-form-field {
   }
 
   .label-top,
-  .label-bottom .field-label-top,
+  .label-bottom,
+  .field-label-top,
   .field-label-bottom {
     position: relative;
     width: 100%;
-    flex: 1;
     max-width: 100%;
+  }
+
+  .label-top,
+  .label-bottom {
+    flex: 0;
+  }
+
+  .field-label-top,
+  .field-label-bottom {
+    flex: 1;
   }
 
   .field-label-left,
@@ -101,7 +111,7 @@ gx-form-field {
     max-height: 100%;
     display: flex;
     flex: 1;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     & > div {
       flex: 1;
       max-height: 100%;
@@ -142,8 +152,10 @@ gx-table-cell {
   &[align="center"],
   &[align="right"] {
     & > gx-form-field {
-      label,
-      label + div {
+      .label-left,
+      .label-right,
+      .field-label-left,
+      .field-label-right {
         -ms-flex-preferred-size: 0;
         flex-basis: 0;
         -webkit-box-flex: 1;

--- a/src/components/renders/bootstrap/form-field/form-field-render.tsx
+++ b/src/components/renders/bootstrap/form-field/form-field-render.tsx
@@ -128,7 +128,16 @@ export class FormFieldRender implements Renderer {
             {label}
           </div>
         ) : (
-          <div class="form-group no-gutters mb-0">
+          <div
+            class={{
+              "form-group": true,
+              "no-gutters": true,
+              "mb-0": true,
+              "flex-column":
+                formField.labelPosition === "top" ||
+                formField.labelPosition === "bottom"
+            }}
+          >
             {renderLabel && renderLabelBefore ? label : null}
             <div class={this.getInnerControlContainerClass()}>
               {slots.default}

--- a/src/components/renders/bootstrap/form-field/form-field.e2e.ts
+++ b/src/components/renders/bootstrap/form-field/form-field.e2e.ts
@@ -19,6 +19,25 @@ describe("gx-form-field", () => {
     expect(labelElement.textContent.trim()).toEqual("Label");
   });
 
+  it("should should use flex column for laying out label and field", async () => {
+    const positions = [
+      ["top", true],
+      ["bottom", true],
+      ["left", false],
+      ["right", false]
+    ];
+
+    const groupElement = await element.find(".form-group");
+    for (const [position, hasFlexColumn] of positions) {
+      element.setAttribute("label-position", position);
+      await page.waitForChanges();
+      if (hasFlexColumn) {
+        expect(groupElement).toHaveClass("flex-column");
+      } else {
+        expect(groupElement).not.toHaveClass("flex-column");
+      }
+    }
+  });
   // it("should link the label and the input field", async () => {
   //   const label = await page.find("label");
   //   const input = await page.find("input");


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fixes the height of the label when `label-position` is `top` or `bottom`.
- Removed wrapping.
- Improved classes that were applying `flex: 1` in all label position cases. Now it's only used when left or right aligned.
- Improved selectors when inside an aligned cell, to use classes instead of tag names.
- Adds unit test for the fix.

#### Testing instructions

1. Using the following HTML code:

```
    <gx-table style="height: 100px">
      <gx-table-cell>
        <gx-form-field label-caption="Label" label-position="top">
          <gx-edit id="edit" value="Hello world!" area="field"></gx-edit>
        </gx-form-field>
      </gx-table-cell>
    </gx-table>
```

2. Verify that:
  a. The text "Label" is rendered on top of the edit field
  b. Both the label and the edit field are completely visible
3. Increase the `gx-table` height to `150px'
4. Verify that the extra space is taken up by the edit field
5. Decrease the `div` height to `60px`
6. Verify that the label is still on top of the edit field

