### PR TITLE
Allow controlling horizontal separator visibility

### DIFF
--- a/src/components/grid-base/grid-base-theming-mixins.scss
+++ b/src/components/grid-base/grid-base-theming-mixins.scss
@@ -45,9 +45,14 @@
     @if ($horizontal-line != null) {
       .gx-grid-row:after,
       * > .gx-grid-row:after {
+        --grid--horizontal-line-separator-default: block;
         @extend #{$horizontal-line} !optional;
         content: "";
         height: var(--height);
+        display: var(
+          --grid--horizontal-line-separator,
+          var(--grid--horizontal-line-separator-default)
+        );
       }
     }
   }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Added `--grid--horizontal-line-separator` custom CSS property to allow controlling the horizontal separator's visibility. Default value is visible (`block`).
