### PR TITLE
Fix form field alignment

### DIFF
--- a/src/components/form-field/form-field.scss
+++ b/src/components/form-field/form-field.scss
@@ -3,4 +3,47 @@
 
 gx-form-field {
   @include visibility(flex);
+
+  justify-self: stretch;
+  align-self: stretch;
+  flex: 1;
+}
+
+[align="center"] {
+  & > gx-form-field {
+    [data-part="field"],
+    [data-readonly] {
+      text-align: center;
+    }
+  }
+}
+
+[align="right"] {
+  & > gx-form-field {
+    [data-part="field"],
+    [data-readonly] {
+      text-align: right;
+    }
+  }
+}
+
+[valign="middle"] {
+  & > gx-form-field {
+    [data-readonly],
+    [data-part="label"] {
+      align-self: center;
+    }
+  }
+}
+
+[valign="bottom"] {
+  & > gx-form-field {
+    [data-readonly] {
+      align-self: flex-end;
+      line-height: 1.25; // WA: Increase line-height minimally to avoid vertical scrollbars
+    }
+    [data-part="label"] {
+      align-self: flex-end;
+    }
+  }
 }

--- a/src/components/renders/bootstrap/edit/edit-render.scss
+++ b/src/components/renders/bootstrap/edit/edit-render.scss
@@ -38,6 +38,7 @@ gx-edit {
     padding: 0;
     line-height: 1.2;
     white-space: break-spaces;
+    flex: 1;
   }
 
   h1,

--- a/src/components/textblock/_textblock-theming-mixins.scss
+++ b/src/components/textblock/_textblock-theming-mixins.scss
@@ -33,4 +33,6 @@
       }
     }
   }
+
+  @include gx-form-field($class);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fixed vertical and horizontal alignment in `gx-form-field` component, when inside an aligned table cell.
- Also, made Textblock's theming mixin to also apply to `gx-form-field` component (atts/vars) because GeneXus allows setting the class of a Textblock to an Attribute or Variable.

