### PR TITLE
Add new gx-layout component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -504,6 +504,24 @@ export namespace Components {
      */
     width: string;
   }
+  interface GxLayout {
+    /**
+     * True to hide the bottom target
+     */
+    bottomHidden: false;
+    /**
+     * True to hide the left target
+     */
+    leftHidden: boolean;
+    /**
+     * True to hide the right target
+     */
+    rightHidden: boolean;
+    /**
+     * True to hide the top target
+     */
+    topHidden: false;
+  }
   interface GxLoading {
     /**
      * Sets the caption text.
@@ -1115,6 +1133,13 @@ declare global {
     prototype: HTMLGxImageElement;
     new (): HTMLGxImageElement;
   };
+  interface HTMLGxLayoutElement
+    extends Components.GxLayout,
+      HTMLStencilElement {}
+  var HTMLGxLayoutElement: {
+    prototype: HTMLGxLayoutElement;
+    new (): HTMLGxLayoutElement;
+  };
   interface HTMLGxLoadingElement
     extends Components.GxLoading,
       HTMLStencilElement {}
@@ -1284,6 +1309,7 @@ declare global {
     "gx-grid-smart": HTMLGxGridSmartElement;
     "gx-group": HTMLGxGroupElement;
     "gx-image": HTMLGxImageElement;
+    "gx-layout": HTMLGxLayoutElement;
     "gx-loading": HTMLGxLoadingElement;
     "gx-lottie": HTMLGxLottieElement;
     "gx-map": HTMLGxMapElement;
@@ -1853,6 +1879,24 @@ declare namespace LocalJSX {
      * This attribute lets you specify the width.
      */
     width?: string;
+  }
+  interface GxLayout {
+    /**
+     * True to hide the bottom target
+     */
+    bottomHidden?: false;
+    /**
+     * True to hide the left target
+     */
+    leftHidden?: boolean;
+    /**
+     * True to hide the right target
+     */
+    rightHidden?: boolean;
+    /**
+     * True to hide the top target
+     */
+    topHidden?: false;
   }
   interface GxLoading {
     /**
@@ -2485,6 +2529,7 @@ declare namespace LocalJSX {
     "gx-grid-smart": GxGridSmart;
     "gx-group": GxGroup;
     "gx-image": GxImage;
+    "gx-layout": GxLayout;
     "gx-loading": GxLoading;
     "gx-lottie": GxLottie;
     "gx-map": GxMap;
@@ -2544,6 +2589,8 @@ declare module "@stencil/core" {
         JSXBase.HTMLAttributes<HTMLGxGridSmartElement>;
       "gx-group": LocalJSX.GxGroup & JSXBase.HTMLAttributes<HTMLGxGroupElement>;
       "gx-image": LocalJSX.GxImage & JSXBase.HTMLAttributes<HTMLGxImageElement>;
+      "gx-layout": LocalJSX.GxLayout &
+        JSXBase.HTMLAttributes<HTMLGxLayoutElement>;
       "gx-loading": LocalJSX.GxLoading &
         JSXBase.HTMLAttributes<HTMLGxLoadingElement>;
       "gx-lottie": LocalJSX.GxLottie &

--- a/src/components/layout/layout.e2e.ts
+++ b/src/components/layout/layout.e2e.ts
@@ -1,0 +1,42 @@
+import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
+
+describe("gx-layout", () => {
+  let element: E2EElement;
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+    <gx-layout>
+      <div slot="top">Top</div>
+      <div slot="right">Right</div>
+      <div slot="bottom">Bottom</div>
+      <div slot="left">Left</div>
+      <div slot>Center</div>
+    </gx-layout>`);
+    element = await page.find("gx-layout");
+  });
+
+  it("should work without parameters", () => {
+    expect(element.textContent.trim().replace(/\s/g, "")).toEqual(
+      "CenterTopLeftRightBottom"
+    );
+  });
+
+  it("should set 'hidden' property in hidden targets", async () => {
+    const targets = [
+      ["topHidden", ".top"],
+      ["rightHidden", ".right"],
+      ["bottomHidden", ".bottom"],
+      ["leftHidden", ".left"]
+    ];
+
+    for (const [prop, targetElementSelector] of targets) {
+      element.setProperty(prop, true);
+      await page.waitForChanges();
+
+      const targetElement = await element.find(targetElementSelector);
+      expect(await targetElement.getProperty("hidden")).toBe(true);
+    }
+  });
+});

--- a/src/components/layout/layout.scss
+++ b/src/components/layout/layout.scss
@@ -1,0 +1,130 @@
+$gx-layout-vertical-targets-breakpoint: 1200px;
+
+gx-layout {
+  /**
+   * @prop --gx-layout-vertical-target-width: Width for vertical targets (left and right)
+   */
+  --gx-layout-vertical-target-width: auto;
+  /**
+   * @prop --gx-layout-horizontal-target-height: Height for horizontal targets (top and bottom)
+   */
+  --gx-layout-horizontal-target-height: auto;
+  /**
+   * @prop --gx-layout-mask-background-color: Mask background color
+   */
+  --gx-layout-mask-background-color: #575965;
+  /**
+   * @prop --gx-layout-mask-opacity: Mask opacity
+   */
+  --gx-layout-mask-opacity: 0.5;
+  /**
+   * @prop --gx-layout-target-transition-duration: Vertical target's transition duration
+   */
+  --gx-layout-target-transition-duration: 0.3s;
+  /**
+   * @prop --gx-layout-target-transition-timing-function: Vertical target's transition timing function
+   */
+  --gx-layout-target-transition-timing-function: ease-in-out;
+
+  display: grid;
+  margin: 0 auto;
+  max-width: 1600px;
+  position: relative;
+  overflow: hidden;
+
+  grid-template-columns:
+    var(--gx-layout-vertical-target-width)
+    1fr
+    var(--gx-layout-vertical-target-width);
+  grid-template-rows:
+    var(--gx-layout-horizontal-target-height)
+    1fr
+    var(--gx-layout-horizontal-target-height);
+  grid-column-gap: 0;
+  grid-row-gap: 0;
+
+  & > .target {
+    display: flex;
+    justify-content: stretch;
+    align-items: stretch;
+    flex-direction: column;
+
+    &[hidden] {
+      display: none !important;
+    }
+  }
+
+  & > .top {
+    grid-area: 1 / 1 / 2 / 4;
+    flex-direction: row;
+  }
+
+  & > .bottom {
+    grid-area: 3 / 1 / 4 / 4;
+    flex-direction: row;
+  }
+
+  & > .left {
+    grid-area: 2 / 1 / 3 / 2;
+
+    @media screen and (max-width: $gx-layout-vertical-targets-breakpoint) {
+      transform: translateX(0);
+      &[hidden] {
+        transform: translateX(-100%);
+      }
+    }
+  }
+
+  & > .center {
+    grid-area: 2 / 2 / 3 / 3;
+    position: relative;
+
+    & > .mask {
+      display: none;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      background-color: var(--gx-layout-mask-background-color);
+      opacity: var(--gx-layout-mask-opacity);
+
+      @media screen and (max-width: $gx-layout-vertical-targets-breakpoint) {
+        &--active {
+          display: block;
+        }
+      }
+    }
+  }
+
+  & > .right {
+    grid-area: 2 / 3 / 3 / 4;
+
+    @media screen and (max-width: $gx-layout-vertical-targets-breakpoint) {
+      transform: translateX(-100%);
+      &[hidden] {
+        transform: translateX(0%);
+      }
+    }
+  }
+
+  & > .vertical {
+    display: flex;
+
+    @media screen and (max-width: $gx-layout-vertical-targets-breakpoint) {
+      position: absolute;
+      z-index: 1;
+      bottom: 0;
+      top: 0;
+      transition-property: transform;
+      transition-duration: var(--gx-layout-target-transition-duration);
+      transition-timing-function: var(
+        --gx-layout-target-transition-timing-function
+      );
+
+      &[hidden] {
+        display: flex !important;
+      }
+    }
+  }
+}

--- a/src/components/layout/layout.scss
+++ b/src/components/layout/layout.scss
@@ -25,6 +25,10 @@ gx-layout {
    * @prop --gx-layout-target-transition-timing-function: Vertical target's transition timing function
    */
   --gx-layout-target-transition-timing-function: ease-in-out;
+  /**
+   * @prop --gx-layout-base-z-index: Base z-index for absolute positioned elements
+   */
+  --gx-layout-base-z-index: 100;
 
   display: grid;
   margin: 0 auto;
@@ -88,6 +92,7 @@ gx-layout {
       left: 0;
       background-color: var(--gx-layout-mask-background-color);
       opacity: var(--gx-layout-mask-opacity);
+      z-index: calc(var(--gx-layout-base-z-index) + 1);
 
       @media screen and (max-width: $gx-layout-vertical-targets-breakpoint) {
         &--active {
@@ -113,7 +118,7 @@ gx-layout {
 
     @media screen and (max-width: $gx-layout-vertical-targets-breakpoint) {
       position: absolute;
-      z-index: 1;
+      z-index: calc(var(--gx-layout-base-z-index) + 2);
       bottom: 0;
       top: 0;
       transition-property: transform;

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,0 +1,98 @@
+import { Component, Element, h, Host, Prop, Watch, State } from "@stencil/core";
+import { Component as GxComponent } from "../common/interfaces";
+
+@Component({
+  shadow: false,
+  styleUrl: "layout.scss",
+  tag: "gx-layout"
+})
+export class Layout implements GxComponent {
+  constructor() {
+    this.handleBodyClick = this.handleBodyClick.bind(this);
+  }
+
+  @Element() element: HTMLGxLayoutElement;
+
+  /**
+   * True to hide the top target
+   */
+  @Prop() readonly topHidden = false;
+
+  /**
+   * True to hide the right target
+   */
+  @Prop({ mutable: true }) rightHidden = false;
+
+  /**
+   * True to hide the bottom target
+   */
+  @Prop() readonly bottomHidden = false;
+
+  /**
+   * True to hide the left target
+   */
+  @Prop({ mutable: true }) leftHidden = false;
+
+  @State() isMaskVisible = !this.rightHidden || !this.leftHidden;
+
+  @Watch("rightHidden")
+  handleRightHiddenChange() {
+    this.updateMaskVisibility();
+  }
+
+  @Watch("leftHidden")
+  handleLeftHiddenChange() {
+    this.updateMaskVisibility();
+  }
+
+  private updateMaskVisibility() {
+    this.isMaskVisible = !this.rightHidden || !this.leftHidden;
+  }
+
+  private handleBodyClick(e: MouseEvent) {
+    if (this.isMaskVisible) {
+      const target = e.target as HTMLElement;
+      console.log(`gx-layout .vertical ${target.tagName}`);
+      if (!target.matches(`gx-layout .vertical ${target.tagName}`)) {
+        this.rightHidden = true;
+        this.leftHidden = true;
+      }
+    }
+  }
+
+  componentDidLoad() {
+    document.body.addEventListener("click", this.handleBodyClick);
+  }
+
+  disconnectedCallback() {
+    document.body.removeEventListener("click", this.handleBodyClick);
+  }
+
+  render() {
+    return (
+      <Host>
+        <main class="target center">
+          <div
+            class={{
+              mask: true,
+              "mask--active": this.isMaskVisible
+            }}
+          ></div>
+          <slot />
+        </main>
+        <header class="target top" hidden={this.topHidden}>
+          <slot name="top" />
+        </header>
+        <aside class="target vertical left" hidden={this.leftHidden}>
+          <slot name="left" />
+        </aside>
+        <aside class="target vertical right" hidden={this.rightHidden}>
+          <slot name="right" />
+        </aside>
+        <footer class="target bottom" hidden={this.bottomHidden}>
+          <slot name="bottom" />
+        </footer>
+      </Host>
+    );
+  }
+}

--- a/src/components/layout/readme.md
+++ b/src/components/layout/readme.md
@@ -1,0 +1,69 @@
+# gx-layout
+
+A container control for creating a simple column layout, consisting of five targets: top, right, bottom left and center:
+
+```
+-------------------------------------
+|                                   |
+|                top                |
+|                                   |
+-------------------------------------
+|          |            |           |
+|  left    |   center   |   right   |
+|          |            |           |
+-------------------------------------
+|                                   |
+|              bottom               |
+|                                   |
+-------------------------------------
+```
+
+The `slot` attribute is used to control where its child elements wil be laid out: "top", "right", "bottom" and "left" are the supported `slot` attribute values. If no slot is specified, the child elements are laid out inside the center target.
+
+## Example
+
+```
+<gx-layout>
+    <div slot="top">Top</div>
+    <div slot="right">Right</div>
+    <div slot="bottom">Bottom</div>
+    <div slot="left">Left</div>
+    <div slot>Center</div>
+</gx-layout>
+```
+
+## Present only once in the page
+
+This control is meant to be used only once in a page and ideally taking all the viewport space.
+
+## Responsive behavior
+
+When the viewport width is less than 1200px the left and right targets stop being fixed and float above the center target.
+
+When the left or right target is visible and floating, the center target is masked. Clicking outside these targets automatically hides them.
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property       | Attribute       | Description                    | Type      | Default |
+| -------------- | --------------- | ------------------------------ | --------- | ------- |
+| `bottomHidden` | `bottom-hidden` | True to hide the bottom target | `boolean` | `false` |
+| `leftHidden`   | `left-hidden`   | True to hide the left target   | `boolean` | `false` |
+| `rightHidden`  | `right-hidden`  | True to hide the right target  | `boolean` | `false` |
+| `topHidden`    | `top-hidden`    | True to hide the top target    | `boolean` | `false` |
+
+## CSS Custom Properties
+
+| Name                                            | Description                                    |
+| ----------------------------------------------- | ---------------------------------------------- |
+| `--gx-layout-horizontal-target-height`          | Height for horizontal targets (top and bottom) |
+| `--gx-layout-mask-background-color`             | Mask background color                          |
+| `--gx-layout-mask-opacity`                      | Mask opacity                                   |
+| `--gx-layout-target-transition-duration`        | Vertical target's transition duration          |
+| `--gx-layout-target-transition-timing-function` | Vertical target's transition timing function   |
+| `--gx-layout-vertical-target-width`             | Width for vertical targets (left and right)    |
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_


### PR DESCRIPTION
New `gx-layout` component for the general layout of pages generated by GeneXus. It's a container control for creating a simple column layout, consisting of five targets: top, right, bottom left and center:

```
-------------------------------------
|                                   |
|                top                |
|                                   |
-------------------------------------
|          |            |           |
|  left    |   center   |   right   |
|          |            |           |
-------------------------------------
|                                   |
|              bottom               |
|                                   |
-------------------------------------
```

#### Changes proposed in this Pull Request

* Added a new `gx-layout` component
* Added unit tests for it
* Added a readme file with documentation for the component

#### Testing instructions

* Use the following HTML:

```
    <gx-layout>
      <div slot="top">Top</div>
      <div slot="right">Right</div>
      <div slot="bottom">Bottom</div>
      <div slot="left">Left</div>
      <div slot>Center</div>
    </gx-layout>
```
* And the following CSS to add some styling:

```
      gx-layout {
        height: 800px;
      }

      [slot] {
        display: flex;
        flex: 1;
        justify-content: center;
        align-items: center;
        background-color: khaki;
      }

      [slot="top"] {
        background-color: aqua;
        height: 120px;
      }

      [slot="right"] {
        background-color: chocolate;
        width: 320px;
      }

      [slot="bottom"] {
        background-color: darkolivegreen;
        height: 100px;
      }

      [slot="left"] {
        background-color: firebrick;
        width: 320px;
      }
```
* Verify that the 5 targets are visible.
* Verify that, with a viewport width of 1200px or more, the left and right targets are statically positioned.
* Verify that, with a viewport width under 1200px:
  - The left and right targets are absolute positioned.
  - Clicking outside the left or right targets should automatically hide them.
  - Clicking inside the left or right targets should not hide them.
  - The center target should be under a opaque gray mask.
