### PR TITLE
Fix auto hiding targets on click

### DIFF
--- a/src/components/layout/layout.scss
+++ b/src/components/layout/layout.scss
@@ -29,6 +29,10 @@ gx-layout {
    * @prop --gx-layout-base-z-index: Base z-index for absolute positioned elements
    */
   --gx-layout-base-z-index: 100;
+  /**
+   * @prop --gx-layout-vertical-targets-breakpoint: Vertical targets breakpoint
+  */
+  --gx-layout-vertical-targets-breakpoint: #{$gx-layout-vertical-targets-breakpoint};
 
   display: grid;
   margin: 0 auto;

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -9,6 +9,7 @@ import { Component as GxComponent } from "../common/interfaces";
 export class Layout implements GxComponent {
   constructor() {
     this.handleBodyClick = this.handleBodyClick.bind(this);
+    this.handleMediaQueryChange = this.handleMediaQueryChange.bind(this);
   }
 
   @Element() element: HTMLGxLayoutElement;
@@ -35,6 +36,9 @@ export class Layout implements GxComponent {
 
   @State() isMaskVisible = !this.rightHidden || !this.leftHidden;
 
+  private mediaQueryList: MediaQueryList;
+  private isVerticalTargetsBreakpoint = false;
+
   @Watch("rightHidden")
   handleRightHiddenChange() {
     this.updateMaskVisibility();
@@ -50,9 +54,8 @@ export class Layout implements GxComponent {
   }
 
   private handleBodyClick(e: MouseEvent) {
-    if (this.isMaskVisible) {
+    if (this.isMaskVisible && this.isVerticalTargetsBreakpoint) {
       const target = e.target as HTMLElement;
-      console.log(`gx-layout .vertical ${target.tagName}`);
       if (!target.matches(`gx-layout .vertical ${target.tagName}`)) {
         this.rightHidden = true;
         this.leftHidden = true;
@@ -62,10 +65,27 @@ export class Layout implements GxComponent {
 
   componentDidLoad() {
     document.body.addEventListener("click", this.handleBodyClick);
+
+    const targetsBreakpoint = getComputedStyle(this.element).getPropertyValue(
+      "--gx-layout-vertical-targets-breakpoint"
+    );
+    this.mediaQueryList = window.matchMedia(
+      `(max-width: ${targetsBreakpoint})`
+    );
+    this.isVerticalTargetsBreakpoint = this.mediaQueryList.matches;
+    this.mediaQueryList.addEventListener("change", this.handleMediaQueryChange);
+  }
+
+  private handleMediaQueryChange(e: MediaQueryListEvent) {
+    this.isVerticalTargetsBreakpoint = e.matches;
   }
 
   disconnectedCallback() {
     document.body.removeEventListener("click", this.handleBodyClick);
+    this.mediaQueryList.removeEventListener(
+      "change",
+      this.handleMediaQueryChange
+    );
   }
 
   render() {

--- a/src/components/layout/readme.md
+++ b/src/components/layout/readme.md
@@ -64,6 +64,7 @@ When the left or right target is visible and floating, the center target is mask
 | `--gx-layout-target-transition-duration`        | Vertical target's transition duration          |
 | `--gx-layout-target-transition-timing-function` | Vertical target's transition timing function   |
 | `--gx-layout-vertical-target-width`             | Width for vertical targets (left and right)    |
+| `--gx-layout-vertical-targets-breakpoint`       | Vertical targets breakpoint                    |
 
 ---
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Targets are now automatically hidden only when they are floating (1200px viewport width or less).
