### PR TITLE
Show gx-navbar links in the bottom in XS screens

### DIFF
--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -1,3 +1,5 @@
+$gx-xsmall-breakpoint: 768px;
+
 @mixin visibility($display) {
   display: $display;
 

--- a/src/components/navbar-link/navbar-link.scss
+++ b/src/components/navbar-link/navbar-link.scss
@@ -1,11 +1,16 @@
 @import "../common/_base";
 
 :host {
-  @include visibility(inline);
+  @include visibility(inline-flex);
   --gx-navbar-link-icon-size: 18px;
 
   font-size: inherit;
   font-weight: inherit;
+
+  @media screen and (max-width: $gx-xsmall-breakpoint) {
+    flex: 1;
+    justify-content: center;
+  }
 
   & > a {
     cursor: pointer;
@@ -25,6 +30,17 @@
       width: var(--gx-navbar-link-icon-size);
       object-fit: contain;
       margin-right: 12px;
+    }
+
+    @media screen and (max-width: $gx-xsmall-breakpoint) {
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+
+      & > .link-icon {
+        margin-bottom: 5px;
+        margin-right: 0;
+      }
     }
   }
 }

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -5,6 +5,8 @@
 
   --gx-navbar-main-background-color: rgb(87, 89, 101);
   --gx-navbar-sub-background-color: trasnparent;
+  --gx-navbar-links-background-color: rgb(224, 224, 224);
+  --gx-navbar-links-color: rgb(147, 148, 152);
   --gx-navbar-main-color: white;
   --gx-navbar-sub-color: black;
   --gx-navbar-main-height: 60px;
@@ -14,6 +16,7 @@
 
   font-size: 14px;
   font-weight: bold;
+  width: 100%;
 
   gx-icon {
     --gx-icon-size: var(--gx-navbar-icon-size);
@@ -68,6 +71,18 @@
       flex-direction: row;
       justify-content: center;
       align-items: center;
+
+      @media screen and (max-width: $gx-xsmall-breakpoint) {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 1;
+        height: 60px;
+        background-color: var(--gx-navbar-links-background-color);
+        color: var(--gx-navbar-links-color);
+        justify-content: stretch;
+      }
     }
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- `gx-navbar` links are now rendered fixed in the bottom of the page in xsmall screens.

