### PR TITLE
Quick fix of Checkbox Control

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -103,6 +103,7 @@ export class CheckBox implements FormComponent {
   }
 
   private handleChange(event: UIEvent) {
+    event.stopPropagation();
     this.checked = this.renderer.getValueFromEvent(event);
     this.updateValue();
     this.input.emit(event);


### PR DESCRIPTION
The error is caused by the emission of two events with the same name.
The `input` element (inside the checkbox render) listens to the `input` custom event and the native `input` event, taking the value of the last event.

Fix solution: prevent emittion (propagation) of "native" `input` event.
> ![image](https://user-images.githubusercontent.com/33690842/89082761-5afe6300-d365-11ea-9d4d-48aeb68641a4.png)
