### PR TITLE
Image component not honoring width when inside Flex container

### DIFF
--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -178,6 +178,12 @@ export class Image
 
     const isHeightSpecified = !!this.height;
     const isWidthSpecified = !!this.width;
+    const height = isHeightSpecified
+      ? `calc(${this.height} + var(--margin-top, 0px) + var(--margin-bottom, 0px))`
+      : null;
+    const width = isWidthSpecified
+      ? `calc(${this.width} + var(--margin-left, 0px) + var(--margin-right, 0px))`
+      : null;
     return (
       <Host
         class={{
@@ -187,12 +193,9 @@ export class Image
         style={{
           alignSelf: isHeightSpecified ? "unset" : null,
           justifySelf: isWidthSpecified ? "unset" : null,
-          height: isHeightSpecified
-            ? `calc(${this.height} + var(--margin-top, 0px) + var(--margin-bottom, 0px))`
-            : null,
-          width: isWidthSpecified
-            ? `calc(${this.width} + var(--margin-left, 0px) + var(--margin-right, 0px))`
-            : null
+          height: height,
+          width: width,
+          maxWidth: width
         }}
       >
         {body}


### PR DESCRIPTION
@ncardeli:
The problem is that when the Image Component is placed inside a Flexbox container, the Width is not honored, but fills the entire container. 

![image](https://user-images.githubusercontent.com/1397693/90182743-d231ef00-dd88-11ea-888f-0c07bc8c05c7.png)

I think that the Image component is the only component whose size can be established via Theme with Image Width and Height (and may not fill the entire "row".) (And not inherited from the parent Cell size. )

I also considered setting the Width to the IMG, but we must resize the whole container, not only the IMG inside, because we expect that Borders are applied to the whole container. 

I've added a maxWidth attribute for this. 

@ncardeli what do you think? Better ideas are welcome. ;)


