### PR TITLE
Add new verticalTargetsBreakpointMatchChange event

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1984,6 +1984,10 @@ declare namespace LocalJSX {
      */
     onRightHiddenChange?: (event: CustomEvent<any>) => void;
     /**
+     * Fired when the viewport size is less than the vertical targets breakpoint.
+     */
+    onVerticalTargetsBreakpointMatchChange?: (event: CustomEvent<any>) => void;
+    /**
      * True to hide the right target
      */
     rightHidden?: boolean;

--- a/src/components/layout/layout.e2e.ts
+++ b/src/components/layout/layout.e2e.ts
@@ -1,5 +1,7 @@
 import { E2EElement, E2EPage, newE2EPage } from "@stencil/core/testing";
 
+const VERTICAL_TARGETS_BREAKPOINT = 1200;
+
 describe("gx-layout", () => {
   let element: E2EElement;
   let page: E2EPage;
@@ -53,7 +55,7 @@ describe("gx-layout", () => {
 
   it("should emit verticalTargetsBreakpointMatchChange event", async () => {
     await page.setViewport({
-      width: 1201,
+      width: VERTICAL_TARGETS_BREAKPOINT + 1,
       height: 768
     });
     await page.waitForChanges();
@@ -63,7 +65,7 @@ describe("gx-layout", () => {
     );
 
     await page.setViewport({
-      width: 768,
+      width: VERTICAL_TARGETS_BREAKPOINT - 1,
       height: 768
     });
     await page.waitForChanges();
@@ -71,7 +73,7 @@ describe("gx-layout", () => {
     expect(spy).toHaveReceivedEventDetail({ matches: true });
 
     await page.setViewport({
-      width: 1201,
+      width: VERTICAL_TARGETS_BREAKPOINT + 1,
       height: 768
     });
     await page.waitForChanges();

--- a/src/components/layout/layout.e2e.ts
+++ b/src/components/layout/layout.e2e.ts
@@ -50,4 +50,32 @@ describe("gx-layout", () => {
     expect(leftHiddenChangeSpy).toHaveReceivedEventDetail(true);
     expect(rightHiddenChangeSpy).toHaveReceivedEventDetail(true);
   });
+
+  it("should emit verticalTargetsBreakpointMatchChange event", async () => {
+    await page.setViewport({
+      width: 1201,
+      height: 768
+    });
+    await page.waitForChanges();
+
+    const spy = await element.spyOnEvent(
+      "verticalTargetsBreakpointMatchChange"
+    );
+
+    await page.setViewport({
+      width: 768,
+      height: 768
+    });
+    await page.waitForChanges();
+
+    expect(spy).toHaveReceivedEventDetail({ matches: true });
+
+    await page.setViewport({
+      width: 1201,
+      height: 768
+    });
+    await page.waitForChanges();
+
+    expect(spy).toHaveReceivedEventDetail({ matches: false });
+  });
 });

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -56,6 +56,11 @@ export class Layout implements GxComponent {
    */
   @Event() rightHiddenChange: EventEmitter;
 
+  /**
+   * Fired when the viewport size is less than the vertical targets breakpoint.
+   */
+  @Event() verticalTargetsBreakpointMatchChange: EventEmitter;
+
   private mediaQueryList: MediaQueryList;
   private isVerticalTargetsBreakpoint = false;
 
@@ -104,12 +109,19 @@ export class Layout implements GxComponent {
     this.mediaQueryList = window.matchMedia(
       `(max-width: ${targetsBreakpoint})`
     );
-    this.isVerticalTargetsBreakpoint = this.mediaQueryList.matches;
+    this.updateVerticalTargetsBreakpointStatus(this.mediaQueryList.matches);
     this.mediaQueryList.addEventListener("change", this.handleMediaQueryChange);
   }
 
-  private handleMediaQueryChange(e: MediaQueryListEvent) {
-    this.isVerticalTargetsBreakpoint = e.matches;
+  private handleMediaQueryChange(event: MediaQueryListEvent) {
+    this.updateVerticalTargetsBreakpointStatus(event.matches);
+  }
+
+  private updateVerticalTargetsBreakpointStatus(matches: boolean) {
+    this.isVerticalTargetsBreakpoint = matches;
+    this.verticalTargetsBreakpointMatchChange.emit({
+      matches
+    });
   }
 
   private endMediaQueryMonitoring() {

--- a/src/components/layout/readme.md
+++ b/src/components/layout/readme.md
@@ -55,10 +55,11 @@ When the left or right target is visible and floating, the center target is mask
 
 ## Events
 
-| Event               | Description                                    | Type               |
-| ------------------- | ---------------------------------------------- | ------------------ |
-| `leftHiddenChange`  | Fired when the leftHidden property is changed  | `CustomEvent<any>` |
-| `rightHiddenChange` | Fired when the rightHidden property is changed | `CustomEvent<any>` |
+| Event                                  | Description                                                                | Type               |
+| -------------------------------------- | -------------------------------------------------------------------------- | ------------------ |
+| `leftHiddenChange`                     | Fired when the leftHidden property is changed                              | `CustomEvent<any>` |
+| `rightHiddenChange`                    | Fired when the rightHidden property is changed                             | `CustomEvent<any>` |
+| `verticalTargetsBreakpointMatchChange` | Fired when the viewport size is less than the vertical targets breakpoint. | `CustomEvent<any>` |
 
 ## CSS Custom Properties
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Added a new event called `verticalTargetsBreakpointMatchChange`. It's emitted every time the viewport size passes the vertical targets breakpoint that establishes when these targets are shown floating or static.
