### PR TITLE
Fix gx-navbar styles

### DIFF
--- a/src/components/navbar-item/navbar-item.scss
+++ b/src/components/navbar-item/navbar-item.scss
@@ -1,4 +1,5 @@
 @import "../common/_base";
+@import "../navbar/_navbar-button-states";
 
 :host {
   @include visibility(inline-flex);
@@ -79,16 +80,24 @@
 
     &:hover,
     &:focus {
-      background-color: var(--gx-navbar-items-color);
+      background-color: var(--gx-navbar-low-hover-background-color);
       color: var(--gx-navbar-main-color);
     }
+  }
+}
+
+:host(:not([slot="low-priority-action"])) {
+  .item {
+    @include button-default-states(3, 15);
   }
 }
 
 :host(:empty) {
   .item {
     &-with-icon {
-      padding: 0;
+      padding: 4px;
+      @include button-default-states();
+      @include button-line-2-states();
     }
 
     &-icon {
@@ -97,4 +106,8 @@
       width: var(--gx-navbar-item-icon-size-big);
     }
   }
+}
+
+:host-context(.gx-navbar-line-2) {
+  @include button-line-2-states();
 }

--- a/src/components/navbar-item/navbar-item.scss
+++ b/src/components/navbar-item/navbar-item.scss
@@ -4,6 +4,8 @@
   @include visibility(inline-flex);
   --gx-navbar-item-icon-size-big: 24px;
   --gx-navbar-item-icon-size-small: 18px;
+  --gx-navbar-item-active-color: inherit;
+  --gx-navbar-item-active-color-xs: #000;
 
   font-size: inherit;
   font-weight: inherit;
@@ -34,6 +36,12 @@
 
     &--active {
       background-color: #888;
+      color: var(--gx-navbar-item-active-color);
+
+      @media screen and (max-width: $gx-xsmall-breakpoint) {
+        background-color: transparent;
+        color: var(--gx-navbar-item-active-color-xs);
+      }
     }
 
     &-icon {
@@ -42,12 +50,17 @@
       width: var(--gx-navbar-item-icon-size-small);
       object-fit: contain;
       margin-right: 12px;
+
+      @media screen and (max-width: $gx-xsmall-breakpoint) {
+        --gx-icon-color: var(--gx-navbar-item-active-color-xs);
+      }
     }
 
     @media screen and (max-width: $gx-xsmall-breakpoint) {
       flex-direction: column;
       justify-content: center;
       align-items: center;
+      text-align: center;
 
       &-icon {
         margin-bottom: 5px;
@@ -61,6 +74,8 @@
   .item {
     padding: 8px 16px;
     margin: 0;
+    justify-content: start;
+    align-items: start;
 
     &:hover,
     &:focus {

--- a/src/components/navbar/_navbar-button-states.scss
+++ b/src/components/navbar/_navbar-button-states.scss
@@ -1,0 +1,44 @@
+@mixin button-default-states(
+  $vertical-padding: 4,
+  $horizontal-padding: 4,
+  $border: 2
+) {
+  padding: #{$vertical-padding}px #{$horizontal-padding}px;
+
+  &:focus {
+    padding: #{$vertical-padding - $border}px #{$horizontal-padding - $border}px;
+    border: #{$border}px solid var(--gx-navbar-main-focus-border-color);
+  }
+
+  &:hover {
+    background-color: var(--gx-navbar-main-hover-background-color);
+  }
+
+  &:active {
+    background-color: var(--gx-navbar-main-active-background-color);
+    color: var(--gx-navbar-main-active-color);
+    gx-icon {
+      --gx-icon-color: var(--gx-navbar-main-active-color);
+    }
+  }
+}
+
+@mixin button-line-2-states() {
+  &:hover {
+    background-color: transparent;
+    color: var(--gx-navbar-sub-hover-color);
+
+    gx-icon {
+      --gx-icon-color: var(--gx-navbar-sub-hover-color);
+    }
+  }
+
+  &:active {
+    background-color: var(--gx-navbar-sub-active-background-color);
+    color: var(--gx-navbar-sub-active-color);
+
+    gx-icon {
+      --gx-icon-color: var(--gx-navbar-sub-active-color);
+    }
+  }
+}

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -7,7 +7,7 @@ gx-navbar {
   --gx-navbar-main-background-color: rgb(87, 89, 101);
   --gx-navbar-sub-background-color: white;
   --gx-navbar-items-background-color: rgb(224, 224, 224);
-  --gx-navbar-items-color: rgb(147, 148, 152);
+  --gx-navbar-items-color: #575965;
   --gx-navbar-main-color: white;
   --gx-navbar-sub-color: black;
   --gx-navbar-main-height: 60px;

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -102,16 +102,16 @@ gx-navbar {
       .gx-navbar-actions {
         flex: 1;
         justify-content: flex-end;
-      }
 
-      .gx-navbar-actions-toggle {
-        gx-icon {
-          --gx-icon-color: var(--gx-navbar-sub-color);
-        }
-
-        &--active {
+        &-toggle {
           gx-icon {
-            --gx-icon-color: var(--gx-navbar-main-color);
+            --gx-icon-color: var(--gx-navbar-sub-color);
+          }
+
+          &--active {
+            gx-icon {
+              --gx-icon-color: var(--gx-navbar-main-color);
+            }
           }
         }
       }
@@ -175,6 +175,9 @@ gx-navbar {
         flex-direction: column;
         border-radius: 2px;
         padding: 5px 0;
+        box-shadow: 0px 3px 4px 0px rgba(0, 0, 0, 0.14),
+          0px 3px 3px -2px rgba(0, 0, 0, 0.12),
+          0px 1px 8px 0px rgba(0, 0, 0, 0.2);
 
         &--active {
           display: flex;

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -189,6 +189,9 @@ gx-navbar {
       border-radius: 100%;
       height: 32px;
       width: 32px;
+      display: inline-flex;
+      place-content: center;
+      place-items: center;
 
       &--active {
         background-color: var(--gx-navbar-actions-low-background-color);

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -1,4 +1,5 @@
 @import "../common/_base";
+@import "./_navbar-button-states";
 
 gx-navbar {
   @include visibility(block);
@@ -6,7 +7,7 @@ gx-navbar {
 
   --gx-navbar-main-background-color: rgb(87, 89, 101);
   --gx-navbar-sub-background-color: white;
-  --gx-navbar-items-background-color: rgb(224, 224, 224);
+  --gx-navbar-items-background-color: #e0e0e0;
   --gx-navbar-items-color: #575965;
   --gx-navbar-main-color: white;
   --gx-navbar-sub-color: black;
@@ -15,8 +16,17 @@ gx-navbar {
   --gx-navbar-icon-size: 24px;
   --gx-navbar-sub-separator-top: none;
   --gx-navbar-sub-separator-bottom: 1px solid rgb(195, 196, 200);
-  --gx-navbar-actions-separator: 1px solid rgb(224, 224, 224);
-  --gx-navbar-actions-low-background-color: rgb(224, 224, 224);
+  --gx-navbar-actions-separator: 1px solid #e0e0e0;
+  --gx-navbar-main-focus-border-color: #e0e0e0;
+  --gx-navbar-main-hover-background-color: #939498;
+  --gx-navbar-main-active-background-color: #c3c4c8;
+  --gx-navbar-main-active-color: #111111;
+  --gx-navbar-sub-focus-border-color: #e0e0e0;
+  --gx-navbar-sub-hover-color: #575965;
+  --gx-navbar-sub-active-background-color: rgba(195, 196, 200, 0.2);
+  --gx-navbar-sub-active-color: #000;
+  --gx-navbar-low-background-color: #e0e0e0;
+  --gx-navbar-low-hover-background-color: #939498;
 
   font-size: 14px;
   font-weight: 600;
@@ -31,13 +41,13 @@ gx-navbar {
   button {
     background: none;
     cursor: pointer;
+    padding: 0;
+    border: 0;
 
     &,
     &:focus,
     &:active {
       appearance: none;
-      padding: 0;
-      border: 0;
       outline: none;
     }
   }
@@ -53,12 +63,20 @@ gx-navbar {
 
     &-header {
       outline: none;
-      color: inherit;
+
+      &,
+      &:hover,
+      &:active,
+      &:focus {
+        color: inherit;
+        text-decoration: none;
+      }
     }
 
     &-icon-button {
-      height: var(--gx-navbar-icon-size);
-      width: var(--gx-navbar-icon-size);
+      line-height: 0;
+
+      @include button-default-states();
     }
 
     &-back-button {
@@ -72,6 +90,9 @@ gx-navbar {
       gx-icon {
         --gx-icon-color: var(--gx-navbar-sub-color);
       }
+
+      @include button-default-states();
+      @include button-line-2-states();
     }
 
     &-target-toggle {
@@ -114,6 +135,10 @@ gx-navbar {
             }
           }
         }
+      }
+
+      .gx-navbar-icon-button {
+        @include button-line-2-states();
       }
     }
 
@@ -164,7 +189,7 @@ gx-navbar {
       &-low {
         display: none;
         width: 160px;
-        background-color: var(--gx-navbar-actions-low-background-color);
+        background-color: var(--gx-navbar-low-background-color);
         color: var(--gx-navbar-sub-color);
         font-weight: 400;
         font-size: 12px;
@@ -195,7 +220,7 @@ gx-navbar {
       place-items: center;
 
       &--active {
-        background-color: var(--gx-navbar-actions-low-background-color);
+        background-color: var(--gx-navbar-low-background-color);
 
         gx-icon {
           --gx-icon-color: var(--gx-navbar-sub-color);

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -189,6 +189,7 @@ gx-navbar {
       border-radius: 100%;
       height: 32px;
       width: 32px;
+      min-width: 32px;
       display: inline-flex;
       place-content: center;
       place-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After the redesign of the `gx-navbar` component done in #122 some styling was unfinished, waiting for the some definitions from the design team. Also, some bugs came up. This PR intends to complete the unfinished work and fix the bugs.

- Added styling for items' states: hover, active and focus
- Improved contraste of navbar links when shown in the bottom (xs screen size)
- Added a shadow to the low priority actions dropdown

