### PR TITLE
Fix default display value of gx-tab-page

### DIFF
--- a/src/components/tab-page/tab-page.scss
+++ b/src/components/tab-page/tab-page.scss
@@ -1,14 +1,15 @@
 @import "../common/_base";
 
 gx-tab-page {
-  @include visibility(block);
+  @include visibility(flex);
   flex: 1;
+  flex-direction: column;
 
   &.gx-tab-page {
     display: none;
 
     &--active {
-      display: block;
+      display: flex;
     }
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Changed the default `display` value for gx-tab-page to `flex`. It must be flex so its child element takes up all the available space by setting `flex: 1`.
