### PR TITLE
Fix navigation items placed in actions slots

### DIFF
--- a/src/components/navbar-item/readme.md
+++ b/src/components/navbar-item/readme.md
@@ -6,13 +6,17 @@ Represents an item with a link inside a `<gx-navbar>`.
 
 ```html
 <gx-navbar caption="Sample">
-  <gx-navbar-item href="#">First item</gx-navbar-item>
-  <gx-navbar-item href="#" active="">Second item (active)</gx-navbar-item>
-  <gx-navbar-item href="#" disabled="">Third item (disabled)</gx-navbar-item>
-  <gx-navbar-item href="#"
+  <gx-navbar-item slot="navigation" href="#">First item</gx-navbar-item>
+  <gx-navbar-item slot="navigation" href="#" active=""
+    >Second item (active)</gx-navbar-item
+  >
+  <gx-navbar-item slot="navigation" href="#" disabled=""
+    >Third item (disabled)</gx-navbar-item
+  >
+  <gx-navbar-item slot="navigation" href="#"
     ><img src="image1.png" />Forth item (with image)</gx-navbar-item
   >
-  <gx-navbar-item href="#"
+  <gx-navbar-item slot="navigation" href="#"
     ><img src="image2.png" /><!-- just an image --></gx-navbar-item
   >
 </gx-navbar>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -138,7 +138,7 @@ export class NavBar implements GxComponent {
               {this.caption}
             </a>
             <div class="gx-navbar-links">
-              <slot />
+              <slot name="navigation" />
             </div>
             {this.singleLine && this.renderActions()}
           </div>

--- a/src/components/navbar/readme.md
+++ b/src/components/navbar/readme.md
@@ -27,11 +27,15 @@ It also supports a set of items that will be rendered according to their priorit
 
 ```html
 <gx-navbar caption="Sample">
-  <gx-navbar-item href="#">First navigation item</gx-navbar-item>
-  <gx-navbar-item href="#" active=""
+  <gx-navbar-item slot="navigation" href="#"
+    >First navigation item</gx-navbar-item
+  >
+  <gx-navbar-item slot="navigation" href="#" active=""
     >Second navigation item (active)</gx-navbar-item
   >
-  <gx-navbar-item href="#">Third navigation item</gx-navbar-item>
+  <gx-navbar-item slot="navigation" href="#"
+    >Third navigation item</gx-navbar-item
+  >
   <gx-navbar-item slot="high-priority-action">High priority</gx-navbar-item>
   <gx-navbar-item slot="normal-priority-action">Normal priority</gx-navbar-item>
   <gx-navbar-item slot="low-priority-action">Low priority</gx-navbar-item>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Navigation items (those that aren't high, normal or low priority actions) were being placed inside the high priority actions target. Even though this looks like a bug on the Stencil side, we can easily solve it by specifying a slot for navigation items too, called `navigation`.

- Used a slot for navigation only items
- Updated readmes, docs and tests
