### PR TITLE
Hide navigation bar at the bottom when empty

### DIFF
--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -160,6 +160,10 @@ gx-navbar {
         background-color: var(--gx-navbar-items-background-color);
         color: var(--gx-navbar-items-color);
         justify-content: stretch;
+
+        &:empty {
+          display: none;
+        }
       }
     }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Hide navigation bar displayed at the bottom when it's empty.

