### PR TITLE
Avoid lazy loading already loaded images

### DIFF
--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -20,6 +20,8 @@ const LAZY_LOAD_CLASS = "gx-lazyload";
 const LAZY_LOADING_CLASS = "gx-lazyloading";
 const LAZY_LOADED_CLASS = "gx-lazyloaded";
 
+const lazyLoadedImages = new Set<string>();
+
 @Component({
   shadow: false,
   styleUrl: "image.scss",
@@ -147,7 +149,7 @@ export class Image
     }
   }
 
-  componentDidUnload() {
+  disconnectedCallback() {
     document.removeEventListener("lazyloaded", this.handleLazyLoaded);
   }
 
@@ -205,6 +207,10 @@ export class Image
       return false;
     }
 
+    if (lazyLoadedImages.has(this.src)) {
+      return false;
+    }
+
     const img: HTMLImageElement = this.element.querySelector("img");
     return img === null || img.classList.contains(LAZY_LOAD_CLASS);
   }
@@ -213,6 +219,7 @@ export class Image
     const img: HTMLImageElement = this.element.querySelector("img");
     if (event.target === img) {
       this.element.classList.remove("gx-img-lazyloading");
+      lazyLoadedImages.add(this.src);
     }
   }
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Added a set to keep track of the already lazy loaded images. If an image has been already lazy loaded, we don't try to lazy load it again. Instead we directly set the `src` attribute of the inner `img` element to load the image.
