### PR TITLE
Show the back button in the main line

### DIFF
--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -64,6 +64,7 @@ gx-navbar {
 
     &-header {
       outline: none;
+      margin-left: 24px;
 
       &,
       &:hover,
@@ -89,15 +90,10 @@ gx-navbar {
       align-items: center;
 
       gx-icon {
-        --gx-icon-color: var(--gx-navbar-sub-color);
+        --gx-icon-color: var(--gx-navbar-main-color);
       }
 
       @include button-default-states();
-      @include button-line-2-states();
-    }
-
-    &-target-toggle {
-      margin-right: 24px;
     }
 
     &-line {
@@ -136,6 +132,14 @@ gx-navbar {
             }
           }
         }
+      }
+
+      .gx-navbar-back-button {
+        gx-icon {
+          --gx-icon-color: var(--gx-navbar-sub-color);
+        }
+
+        @include button-line-2-states();
       }
 
       .gx-navbar-icon-button {

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -132,6 +132,16 @@ export class NavBar implements GxComponent {
       >
         <nav class="gx-navbar">
           <div class="gx-navbar-line gx-navbar-line-1">
+            {this.showBackButton && this.singleLine && (
+              <button
+                type="button"
+                class="gx-navbar-back-button gx-navbar-icon-button"
+                aria-label={this.backButtonLabel}
+                onClick={this.handleBackButtonClick}
+              >
+                <gx-icon type="arrow-left"></gx-icon>
+              </button>
+            )}
             {this.showToggleButton && (
               <button
                 type="button"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- When `singleLine=true` and `showBackButton=true` that back button is displayed in the main line of the navigation bar.
