### PR TITLE
Fix navbar not refreshing when items removed

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1459,10 +1459,6 @@ declare namespace LocalJSX {
      */
     invisibleMode?: "collapse" | "keep-space";
     /**
-     * Emitted when the element is clicked.
-     */
-    onGxClick?: (event: CustomEvent<any>) => void;
-    /**
      * This attribute lets you specify the size of the button.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `large`  | Large sized button.                                     | | `normal` | Standard sized button.                                  | | `small`  | Small sized button.                                     |
      */
     size?: "large" | "normal" | "small";
@@ -2275,14 +2271,6 @@ declare namespace LocalJSX {
      * This attribute lets you specify the URL of an icon for the navbar item.
      */
     iconSrc?: "";
-    /**
-     * Fired after the component has been rendered in the page for the first time
-     */
-    onNavBarItemLoaded?: (event: CustomEvent<any>) => void;
-    /**
-     * Fired after the component has been removed from the page
-     */
-    onNavBarItemUnloaded?: (event: CustomEvent<any>) => void;
   }
   interface GxPasswordEdit {
     /**

--- a/src/components/common/watch-items.ts
+++ b/src/components/common/watch-items.ts
@@ -1,0 +1,43 @@
+export const watchForItems = <T extends HTMLElement>(
+  containerEl: HTMLElement,
+  tagName: string,
+  onChange: (el: T | undefined) => void
+) => {
+  if (typeof MutationObserver === "undefined") {
+    return;
+  }
+
+  const mutation = new MutationObserver(mutationList => {
+    onChange(getSelectedItem<T>(mutationList, tagName));
+  });
+  mutation.observe(containerEl, {
+    childList: true,
+    subtree: true
+  });
+  return mutation;
+};
+
+function getSelectedItem<T extends HTMLElement>(
+  mutationList: MutationRecord[],
+  tagName: string
+): T | undefined {
+  let newOption: HTMLElement | undefined;
+  mutationList.forEach(mut => {
+    for (let i = 0; i < mut.addedNodes.length; i++) {
+      newOption = findCheckedItem(mut.addedNodes[i], tagName) || newOption;
+    }
+  });
+  return newOption as any;
+}
+
+export function findCheckedItem(el: any, tagName: string) {
+  if (el.nodeType !== 1) {
+    return undefined;
+  }
+  const options: HTMLElement[] =
+    el.tagName === tagName.toUpperCase()
+      ? [el]
+      : Array.from(el.querySelectorAll(tagName));
+
+  return options.find((o: any) => o.value === el.value);
+}

--- a/src/components/navbar-item/navbar-item.tsx
+++ b/src/components/navbar-item/navbar-item.tsx
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Element,
-  Host,
-  Prop,
-  h,
-  Event,
-  EventEmitter
-} from "@stencil/core";
+import { Component, Element, Host, Prop, h } from "@stencil/core";
 import { Component as GxComponent } from "../common/interfaces";
 
 @Component({
@@ -36,24 +28,6 @@ export class NavBarItem implements GxComponent {
    * This attribute lets you specify the URL of an icon for the navbar item.
    */
   @Prop() readonly iconSrc = "";
-
-  /**
-   * Fired after the component has been rendered in the page for the first time
-   */
-  @Event() navBarItemLoaded: EventEmitter;
-
-  /**
-   * Fired after the component has been removed from the page
-   */
-  @Event() navBarItemUnloaded: EventEmitter;
-
-  componentDidLoad() {
-    this.navBarItemLoaded.emit(this.element);
-  }
-
-  disconnectedCallback() {
-    this.navBarItemUnloaded.emit(this.element);
-  }
 
   render() {
     const TagName = this.href ? "a" : "button";

--- a/src/components/navbar-item/readme.md
+++ b/src/components/navbar-item/readme.md
@@ -33,13 +33,6 @@ Represents an item with a link inside a `<gx-navbar>`.
 | `iconAltText` | `icon-alt-text` | This attribute lets you specify the alternate text for the image specified in iconSrc.                  | `""`      | `""`    |
 | `iconSrc`     | `icon-src`      | This attribute lets you specify the URL of an icon for the navbar item.                                 | `""`      | `""`    |
 
-## Events
-
-| Event                | Description                                                                | Type               |
-| -------------------- | -------------------------------------------------------------------------- | ------------------ |
-| `navBarItemLoaded`   | Fired after the component has been rendered in the page for the first time | `CustomEvent<any>` |
-| `navBarItemUnloaded` | Fired after the component has been removed from the page                   | `CustomEvent<any>` |
-
 ---
 
 _Built with [StencilJS](https://stenciljs.com/)_


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fixed the navbar not refreshing correctly when child `gx-navbar-items` were removed. The old mechanism relayed on an event fired from the child elements when disconnected. This approach didn't work because the event was fired when the element was already disconnected from the DOM. The new mechanism uses `MutationObserver` to monitor its child elements.
