### PR TITLE
Disable onClick bubbling for gx-edit editable fields. 

### DIFF
--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -219,6 +219,9 @@ export class Edit implements FormComponent {
   }
 
   private handleTriggerClick(event: UIEvent) {
+    if (!this.disabled) {
+      event.stopPropagation();
+    }
     this.gxTriggerClick.emit(event);
   }
 

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -65,6 +65,10 @@ export class EditRender implements Renderer {
     return event.target && (event.target as HTMLInputElement).value;
   }
 
+  stopPropagation(event: UIEvent) {
+    event.stopPropagation();
+  }
+
   /**
    * Update the native input element when the value changes
    */
@@ -97,6 +101,7 @@ export class EditRender implements Renderer {
       id: this.inputId,
       onChange: this.handleChange,
       onInput: valueChangingHandler,
+      onClick: edit.disabled ? null : this.stopPropagation,
       placeholder: edit.placeholder
     };
 


### PR DESCRIPTION
Sample:

```
<table click="UserEvent()">
    <gx-edit>
    </gx-edit>
</table>
```

If a click was made inside a gx-edit (to change the Value or Set the Focus), the Table UserEvent was fired (event bubbling).

Another option could be to handle this situation inside the Table implementation, checking for the Event target control. 


