### PR TITLE
New Grid Empty Indicator Component

### DIFF
--- a/src/components/grid-base/grid-base.scss
+++ b/src/components/grid-base/grid-base.scss
@@ -10,6 +10,10 @@
   & > [slot="grid-empty-loading-placeholder"] {
     @include visibility(none);
   }
+
+  & > .grid-empty-placeholder > [slot="grid-content-empty"] {
+    flex: 1;
+  }
 }
 
 .gx-grid-base.gx-grid-empty:not(.gx-grid-loading) {

--- a/src/components/grid-empty-indicator/grid-empty-indicator.scss
+++ b/src/components/grid-empty-indicator/grid-empty-indicator.scss
@@ -1,0 +1,19 @@
+@import "../common/_base";
+
+gx-grid-empty-indicator {
+  @include visibility(flex);
+  height: 100%;
+
+  & > gx-canvas {
+    flex: 1;
+    & > gx-canvas-cell.empty-text,
+    & > gx-canvas-cell.empty-image {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      z-index: 1;
+      text-align: center;
+      align-items: center;
+    }
+  }
+}

--- a/src/components/grid-empty-indicator/grid-empty-indicator.tsx
+++ b/src/components/grid-empty-indicator/grid-empty-indicator.tsx
@@ -9,31 +9,26 @@ const EMPTY_TEXT_CLASS = "empty-text";
   tag: "gx-grid-empty-indicator"
 })
 export class GridEmptyIndicator implements ComponentInterface {
-  @Prop() readonly emptyGridText: string;
-  @Prop() readonly emptyGridTextClass: string;
-  @Prop() readonly emptyGridBackgroundImage: string;
-  @Prop() readonly emptyGridBackgroundClass: string;
+  @Prop() readonly text = "";
+  @Prop() readonly textClass = "";
+  @Prop() readonly image = "";
+  @Prop() readonly imageClass = "";
 
   render() {
     return (
       <Host>
         <gx-canvas>
-          {this.emptyGridText ? (
+          {this.image ? (
             <gx-canvas-cell class={EMPTY_IMAGE_CLASS}>
               {/* 
               // @ts-ignore */}
-              <gx-image
-                src={this.emptyGridBackgroundImage}
-                class={this.emptyGridBackgroundClass}
-              ></gx-image>
+              <gx-image src={this.image} class={this.imageClass}></gx-image>
             </gx-canvas-cell>
           ) : null}
 
-          {this.emptyGridBackgroundImage ? (
+          {this.text ? (
             <gx-canvas-cell class={EMPTY_TEXT_CLASS}>
-              <gx-textblock class={this.emptyGridTextClass}>
-                {this.emptyGridText}
-              </gx-textblock>
+              <gx-textblock class={this.textClass}>{this.text}</gx-textblock>
             </gx-canvas-cell>
           ) : null}
         </gx-canvas>

--- a/src/components/grid-empty-indicator/grid-empty-indicator.tsx
+++ b/src/components/grid-empty-indicator/grid-empty-indicator.tsx
@@ -9,9 +9,24 @@ const EMPTY_TEXT_CLASS = "empty-text";
   tag: "gx-grid-empty-indicator"
 })
 export class GridEmptyIndicator implements ComponentInterface {
+  /**
+   * Text to be displayed
+   */
   @Prop() readonly text = "";
+
+  /**
+   * A CSS class to set as the inner `text` element class.
+   */
   @Prop() readonly textClass = "";
+
+  /**
+   * Image url to be shown
+   */
   @Prop() readonly image = "";
+
+  /**
+   * A CSS class to set as the inner `image` element class.
+   */
   @Prop() readonly imageClass = "";
 
   render() {

--- a/src/components/grid-empty-indicator/grid-empty-indicator.tsx
+++ b/src/components/grid-empty-indicator/grid-empty-indicator.tsx
@@ -1,0 +1,43 @@
+import { Component, ComponentInterface, h, Host, Prop } from "@stencil/core";
+
+const EMPTY_IMAGE_CLASS = "empty-image";
+const EMPTY_TEXT_CLASS = "empty-text";
+
+@Component({
+  shadow: false,
+  styleUrl: "grid-empty-indicator.scss",
+  tag: "gx-grid-empty-indicator"
+})
+export class GridEmptyIndicator implements ComponentInterface {
+  @Prop() readonly emptyGridText: string;
+  @Prop() readonly emptyGridTextClass: string;
+  @Prop() readonly emptyGridBackgroundImage: string;
+  @Prop() readonly emptyGridBackgroundClass: string;
+
+  render() {
+    return (
+      <Host>
+        <gx-canvas>
+          {this.emptyGridText ? (
+            <gx-canvas-cell class={EMPTY_IMAGE_CLASS}>
+              {/* 
+              // @ts-ignore */}
+              <gx-image
+                src={this.emptyGridBackgroundImage}
+                class={this.emptyGridBackgroundClass}
+              ></gx-image>
+            </gx-canvas-cell>
+          ) : null}
+
+          {this.emptyGridBackgroundImage ? (
+            <gx-canvas-cell class={EMPTY_TEXT_CLASS}>
+              <gx-textblock class={this.emptyGridTextClass}>
+                {this.emptyGridText}
+              </gx-textblock>
+            </gx-canvas-cell>
+          ) : null}
+        </gx-canvas>
+      </Host>
+    );
+  }
+}

--- a/src/components/grid-empty-indicator/readme.md
+++ b/src/components/grid-empty-indicator/readme.md
@@ -16,12 +16,12 @@ This control shows a text element with an image in the background. It also suppo
 
 ## Properties
 
-| Property     | Attribute     | Description | Type | Default |
-| ------------ | ------------- | ----------- | ---- | ------- |
-| `image`      | `image`       |             | `""` | `""`    |
-| `imageClass` | `image-class` |             | `""` | `""`    |
-| `text`       | `text`        |             | `""` | `""`    |
-| `textClass`  | `text-class`  |             | `""` | `""`    |
+| Property     | Attribute     | Description                                            | Type | Default |
+| ------------ | ------------- | ------------------------------------------------------ | ---- | ------- |
+| `image`      | `image`       | Image url to be shown                                  | `""` | `""`    |
+| `imageClass` | `image-class` | A CSS class to set as the inner `image` element class. | `""` | `""`    |
+| `text`       | `text`        | Text to be displayed                                   | `""` | `""`    |
+| `textClass`  | `text-class`  | A CSS class to set as the inner `text` element class.  | `""` | `""`    |
 
 ## Dependencies
 

--- a/src/components/grid-empty-indicator/readme.md
+++ b/src/components/grid-empty-indicator/readme.md
@@ -1,0 +1,48 @@
+# gx-grid-empty-indicator
+
+This control shows a text element with an image in the background. It also supports a class for text and background image.
+
+```html
+<gx-grid-empty-indicator
+  text="My Empty Grid Text"
+  text-class="MyTextClass"
+  image="image.png"
+  image-class="MyImageClass"
+>
+</gx-grid-empty-indicator>
+```
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property     | Attribute     | Description | Type | Default |
+| ------------ | ------------- | ----------- | ---- | ------- |
+| `image`      | `image`       |             | `""` | `""`    |
+| `imageClass` | `image-class` |             | `""` | `""`    |
+| `text`       | `text`        |             | `""` | `""`    |
+| `textClass`  | `text-class`  |             | `""` | `""`    |
+
+## Dependencies
+
+### Depends on
+
+- [gx-canvas](../canvas)
+- [gx-canvas-cell](../canvas-cell)
+- [gx-image](../image)
+- [gx-textblock](../textblock)
+
+### Graph
+
+```mermaid
+graph TD;
+  gx-grid-empty-indicator --> gx-canvas
+  gx-grid-empty-indicator --> gx-canvas-cell
+  gx-grid-empty-indicator --> gx-image
+  gx-grid-empty-indicator --> gx-textblock
+  style gx-grid-empty-indicator fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/grid-smart/grid-smart.scss
+++ b/src/components/grid-smart/grid-smart.scss
@@ -1,8 +1,14 @@
 @import "../grid-base/grid-base.scss";
 @import "../../../node_modules/swiper/css/swiper.min.css";
 
-.swiper-slide {
-  //Reset CSS required properties.
-  flex-grow: 0;
-  flex-basis: auto;
+gx-grid-smart {
+  & > [slot="grid-empty-loading-placeholder"] {
+    height: 100%;
+  }
+
+  .swiper-slide {
+    //Reset CSS required properties.
+    flex-grow: 0;
+    flex-basis: auto;
+  }
 }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -38,7 +38,8 @@ export const config: Config = {
         "gx-grid-fs",
         "gx-grid-smart",
         "gx-grid-infinite-scroll",
-        "gx-grid-infinite-scroll-content"
+        "gx-grid-infinite-scroll-content",
+        "gx-grid-empty-indicator"
       ]
     }
   ],


### PR DESCRIPTION
New Grid Empty Indicator Component. Supports: 

- Empty Grid Background Image
- Empty Grid Background Image Class
- Empty Grid Text
- Empty Grid Text Class

```html
<gx-grid-empty-indicator
  text="My Empty Grid Text"
  text-class="MyTextClass"
  image="image.png"
  image-class="MyImageClass"
>
</gx-grid-empty-indicator>
```