### PR TITLE
triggerText now is displayed if slot is not setted

### DIFF
--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -112,6 +112,9 @@ export class EditRender implements Renderer {
       const input = <input {...attris} type={edit.type} value={edit.value} />;
 
       if (edit.showTrigger) {
+        const existSlotContent = edit.element.querySelector(
+          "[slot='trigger-content']"
+        );
         editableElement = (
           <div class="input-group" hidden={edit.readonly}>
             {input}
@@ -123,7 +126,9 @@ export class EditRender implements Renderer {
                 disabled={edit.disabled}
                 aria-label={edit.triggerText}
               >
-                {slots.triggerContent}
+                {existSlotContent !== null
+                  ? slots.triggerContent
+                  : edit.triggerText}
               </button>
             </div>
           </div>

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -69,7 +69,7 @@ export class EditRender implements Renderer {
     event.stopPropagation();
   }
 
-  setReadonlyContent(component, initialContent) {
+  getReadonlyContent(component, initialContent) {
     let content = initialContent;
     if (
       content &&
@@ -189,7 +189,7 @@ export class EditRender implements Renderer {
             {"A"}
           </div>
         )}
-        {this.setReadonlyContent(edit, edit.value)}
+        {this.getReadonlyContent(edit, edit.value)}
       </ReadonlyTag>,
       editableElement
     ];

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -71,7 +71,6 @@ export class EditRender implements Renderer {
 
   setReadonlyContent(component, initialContent) {
     let content = initialContent;
-    console.log(content);
     if (
       content &&
       (component.type === "datetime-local" || component.type === "date")

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -69,6 +69,35 @@ export class EditRender implements Renderer {
     event.stopPropagation();
   }
 
+  setReadonlyContent(component, initialContent) {
+    let content = initialContent;
+    console.log(content);
+    if (
+      content &&
+      (component.type === "datetime-local" || component.type === "date")
+    ) {
+      const dateTime = new Date(component.value);
+      if (component.type === "date") {
+        dateTime.setDate(dateTime.getDate() + 1);
+      }
+      const dayMonthYear = new Intl.DateTimeFormat("default", {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric"
+      }).format(dateTime);
+      if (component.type === "date") {
+        content = `${dayMonthYear}`;
+      } else {
+        const hourMins = new Intl.DateTimeFormat("default", {
+          hour: "numeric",
+          minute: "numeric"
+        }).format(dateTime);
+        content = `${dayMonthYear} ${hourMins}`;
+      }
+    }
+    return content;
+  }
+
   /**
    * Update the native input element when the value changes
    */
@@ -161,7 +190,7 @@ export class EditRender implements Renderer {
             {"A"}
           </div>
         )}
-        {edit.value}
+        {this.setReadonlyContent(edit, edit.value)}
       </ReadonlyTag>,
       editableElement
     ];


### PR DESCRIPTION
When `show-trigger = true`  you can set the `trigger-text` with some text to show within the button.
The bug was an error where `trigger-text` never was within the button. 

Now, if  `show-trigger = true` and you don't set a `slot` element, the `trigger-text` will be displayed.
If you set a `slot` element,  the `trigger-text` value only will be as an aria-attr value, and the button will the content setted in the `slot` element.