### PR TITLE
GXMap: ParseGeoJson should not throw Exception when coords is empty

### DIFF
--- a/src/components/common/coordsValidate.ts
+++ b/src/components/common/coordsValidate.ts
@@ -4,16 +4,17 @@ export function parseCoords(coord): string[] {
   if (result !== null) {
     return result.slice(1);
   } else {
-    return parseGeoJson(coord);
+    return tryParseGeoJson(coord);
   }
 }
 
-function parseGeoJson(coord) {
+function tryParseGeoJson(coord) {
   let geoObject;
+
   try {
     geoObject = JSON.parse(coord);
   } catch (e) {
-    throw new Error(e);
+    return null;
   }
   const hasType = geoObject.hasOwnProperty("type");
   if (hasType) {


### PR DESCRIPTION
The error occurred when a Geolocation "Coords" or "Center" Property had "" empty string. 

This happens when:
- Geolocation is empty from Server Side
- At first component initialization (before server side data)