### PR TITLE
Update controls to follow GeneXus UI criteria

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -28,6 +28,16 @@ export namespace Components {
      */
     disabled: false;
   }
+  interface GxAudio {
+    /**
+     * This attribute lets you specify if the element is disabled.
+     */
+    disabled: false;
+    /**
+     * This attribute is for specifies the src of the audio.
+     */
+    src: string;
+  }
   interface GxBootstrap {}
   interface GxButton {
     /**
@@ -1098,6 +1108,11 @@ declare global {
     prototype: HTMLGxActionSheetItemElement;
     new (): HTMLGxActionSheetItemElement;
   };
+  interface HTMLGxAudioElement extends Components.GxAudio, HTMLStencilElement {}
+  var HTMLGxAudioElement: {
+    prototype: HTMLGxAudioElement;
+    new (): HTMLGxAudioElement;
+  };
   interface HTMLGxBootstrapElement
     extends Components.GxBootstrap,
       HTMLStencilElement {}
@@ -1375,6 +1390,7 @@ declare global {
   interface HTMLElementTagNameMap {
     "gx-action-sheet": HTMLGxActionSheetElement;
     "gx-action-sheet-item": HTMLGxActionSheetItemElement;
+    "gx-audio": HTMLGxAudioElement;
     "gx-bootstrap": HTMLGxBootstrapElement;
     "gx-button": HTMLGxButtonElement;
     "gx-canvas": HTMLGxCanvasElement;
@@ -1447,6 +1463,16 @@ declare namespace LocalJSX {
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, gxClick event).
      */
     disabled?: false;
+  }
+  interface GxAudio {
+    /**
+     * This attribute lets you specify if the element is disabled.
+     */
+    disabled?: false;
+    /**
+     * This attribute is for specifies the src of the audio.
+     */
+    src?: string;
   }
   interface GxBootstrap {}
   interface GxButton {
@@ -2676,6 +2702,7 @@ declare namespace LocalJSX {
   interface IntrinsicElements {
     "gx-action-sheet": GxActionSheet;
     "gx-action-sheet-item": GxActionSheetItem;
+    "gx-audio": GxAudio;
     "gx-bootstrap": GxBootstrap;
     "gx-button": GxButton;
     "gx-canvas": GxCanvas;
@@ -2728,6 +2755,7 @@ declare module "@stencil/core" {
         JSXBase.HTMLAttributes<HTMLGxActionSheetElement>;
       "gx-action-sheet-item": LocalJSX.GxActionSheetItem &
         JSXBase.HTMLAttributes<HTMLGxActionSheetItemElement>;
+      "gx-audio": LocalJSX.GxAudio & JSXBase.HTMLAttributes<HTMLGxAudioElement>;
       "gx-bootstrap": LocalJSX.GxBootstrap &
         JSXBase.HTMLAttributes<HTMLGxBootstrapElement>;
       "gx-button": LocalJSX.GxButton &

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -20,6 +20,9 @@ gx-button {
     position: relative;
     align-items: center;
     justify-content: center;
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: contain;
 
     & > img {
       height: var(--gx-button-image-size);

--- a/src/components/canvas/canvas.scss
+++ b/src/components/canvas/canvas.scss
@@ -4,4 +4,5 @@ gx-canvas {
   @include visibility(block);
 
   position: relative;
+  overflow: hidden;
 }

--- a/src/components/edit/edit.scss
+++ b/src/components/edit/edit.scss
@@ -5,4 +5,14 @@ gx-edit {
   @include visibility(flex);
   align-items: stretch;
   flex: 1;
+
+  &.gx-edit {
+    &--single-line {
+      [data-readonly] {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
 }

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -236,7 +236,12 @@ export class Edit implements FormComponent {
 
   render() {
     return (
-      <Host>
+      <Host
+        class={{
+          "gx-edit--single-line":
+            this.type === "date" || this.type === "datetime-local"
+        }}
+      >
         {this.renderer.render({
           triggerContent: <slot name="trigger-content" />
         })}

--- a/src/components/image/image.e2e.ts
+++ b/src/components/image/image.e2e.ts
@@ -6,7 +6,6 @@ const testImage1Width = 32;
 
 const testImage2 =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAi4AAAEOCAMAAACZ0GxGAAAAOVBMVEUiIiLghSTRfSMpNDdKNiIsPEBBXmZGZ3C7ciOGViKUXSM1LCKkZSM7VFpwSiJeQSIlKisvREkwSlHe9VrNAAAGwElEQVR4Xu3dWZbqRhAG4axJ88j+F2s3jS03CZ2FwLIL4tvAfeHcUP/JQfI3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwJMkCRBGpqiQZgKYXWeu6WhcxAL1rRZb6y8n4wACt8yIy1hkfGKBxLoqk+mIMcg8QnXPdpUbmBwa0yF1qZH5gAO/+NIuE+p+qJAoQ3ZdBRKra+MAAnTvrRU71FT3EgBadTecaKatsgNl9a8410mQDDO4iiqy1luQaaJG7HAKUUa6AFm3Ti7LINdCi8/SSfnnYBXq36USk1ir5BkzOmTUKcgY0bnNvejnJFdCi7RBg1wi0SB8CdI1AizZTxvQCWmQfAoDWbXIPAaBF5iEAiG6TewgALeIQYIN3ymAcAkCLmF5s6JxiHQJAi+zphRphdjf15vQCWmRPL6BFWmNOL6BFm6imF2qEwd3R3a0ROEZzCLBhckr+IQC0yP4OJmgRh4B8tIhDgA2NU/gOpoUWcQiwoXUKhwALLWJ6sSE6QzSmF9Ai+xBQCThGUyMDLTLMTC8X6JzCIcBCizgE2DA7JfsQMApo0e5DAGgRP8ag0SIOATYMzmBPL+AYzXcwNUzOwI8xaLTIxq8yo3fZ+A4mJpeNH2NA4/L1ImtWjUCLmF7QOuX5QwBoEYcARPeQTkSCtghokeYFHKPzzVIe9O2V7r6h64Z7Gveg5kX/cJQDITauYD7KsdC5Yg29fFmCHAazd2Wa5Gw5ndYgR0FfZJCaKGfp9GUNAoJkhmg9XayMNgTJCFE4bfjAEKScEG3SIsdAW1CIZAsRHxiClB8iLckh0A8lhkgL8g0EqdMh0oIcAfF/HiSvQqQwwxCkvBAd/4HBVHKImGE4UqsQZVrkEASp6BCx8RKk/BDxxxFB8nNuiDgfcaRuejtELLvcBAgRR2pCRJAIEWZfXIgWKQNBIkRoiwgRYwtB0iFibOEm8HyIGFsIUtMztuTiW1MtISJI+SFibOFIvTdE7Lgcqe0QlTy2YDgqRIwtBIkQvR5BahlbOFITotfiJkCIOFITIrT/dYgYWwjSQIgI0utDxNhCkHwkRLxjPJffQsTYwtvRTD0h4iDw4M/NjYSIe2P+b1mO9UiIeIFR7uuwUl3XI2MLT7q2Wf56+evIjmvh1Nh91+isYmyhRRk1WuuL6q1ChOheLV5qdFERIkZd6whQ1ZvqbUKExr1aI3861f9UESIm3d+G3VD/VBEiJt1fht36WsXYwqT7y7CrVCcBk+7NGqVaqwRMuveGXS0ImHSNGm1WAS26O+xSIybd/GFXWwRMujfPjBU1YtJ9rkajgEn3Zo0CNWLSfejMqCUBk+7NM+P4VjWC2xw17NYCJl3jzMiwy6S7b9g9CZh0lc8edpl0PWfGXEy6fpaOYZdJ94Ff+Jk8Z0Ybk66fct+4xrDLpNv0e/6Yaj+yRky6rXxZkn7jmj3snt5k2MVjPx4WLl/j10Gyh93ya4Q5+xl3e79MkC/ts8NuktKge+CVIeHnu6mi58zIpHv3GTddvxWkHzgzXmPSbW+9Xybk/1k1fc6wy6TbxJ8hugpSk3lmrD7hzMik26n/Wn4GSTqGXSZd9Yx7S8icYGYRCW9fIybdQT3jqiBdJhjOjEy6kwrRnSC1GTU6FV8j7HjGNYL0vmdGzDl/PhtWsSeYVg27BdYInX0iUowgve+wC5//jGsHKfqPPDMy6fpp18uI+uHxYTdJKdD+eiIKj7/nbPq4GjHptk+85yw2v9RoLfnMiN58xrUFudIZw+471YhJt3v6hZuz/5AzI5Ounx8KUTDeMfzWwy4tGnY942rtB5wZmXSnl73LN/rblauLrRE680S0/xWK/XCzRmOxNYJ/4hk3Pf4cHUsedhGfesa1xUbPOUupZ0a0Tz7j2ob3GXbR7H3GDZJr8mrYLbNG6J9/xrX1zZudGZl02yeecW2dGnYLrhEt8tEI0e7/WvRNQA27pZwZ0e/ZcZPs0DfFnxkx7/gaVJB9WjXsFlYjDHu+BrVX9GUPu/CPPuMGeUI/qGG3oDMjomte+Yxrm9SwW86ZEW0nL3/GtW8CTZk1wgH/tSjdd43W0mqEI/5r0WZf4pkRxzzjav05gVWJNUI6IERKsWdGLClnmXu9MBY57GJJ9jJ3zAdmlMLxgUny7wljoTUiSfYyd0CSkhSMJCX514XqTWpEkoIcIVWFfumFJKkQHfyBCVImkhTkQKkq8syIZVXL3IFJqqRAfGCSHC9VRdYIyyLKQUlaJReQRnkfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD8AWaaezX+7YmeAAAAAElFTkSuQmCC";
-const testImage2Width = 558;
 
 describe("gx-image", () => {
   let element: E2EElement;
@@ -15,7 +14,7 @@ describe("gx-image", () => {
   beforeEach(async () => {
     page = await newE2EPage();
     await page.setContent(
-      "<gx-image src='img.png' alt='Alternate text'></gx-image>"
+      "<div style='display: flex; width: 100px;'><gx-image src='img.png' alt='Alternate text'></gx-image></div>"
     );
     element = await page.find("gx-image");
   });
@@ -42,7 +41,7 @@ describe("gx-image", () => {
 
     await element.setProperty("src", testImage2);
     await page.waitForChanges();
-    expect(await element.getProperty("width")).toEqual(`${testImage2Width}px`);
+    expect(await element.getProperty("width")).toEqual(`100px`);
   });
 
   it("should fire click event", async () => {

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -144,10 +144,11 @@ export class Image
       const img = event.target as HTMLImageElement;
       // Some image formats do not specify intrinsic dimensions. The naturalWidth property returns 0 in those cases.
       if (img.naturalWidth !== 0) {
-        this.width = `${Math.min(
-          img.naturalWidth,
-          this.element.clientWidth
-        )}px`;
+        this.width = `${
+          this.element.clientWidth > 0
+            ? Math.min(img.naturalWidth, this.element.clientWidth)
+            : img.naturalWidth
+        }px`;
       }
     }
   }

--- a/src/components/tab/readme.md
+++ b/src/components/tab/readme.md
@@ -60,7 +60,9 @@ tab content, using the `gx-tab-page` element.
 | `--tab-caption-image-horizontal-margin` | Tab caption image horizontal margin          |
 | `--tab-caption-image-vertical-margin`   | Tab caption image vertical margin            |
 | `--tab-caption-vertical-padding`        | Tab caption vertical padding                 |
+| `--tab-strip-background-color`          | Tab strip background color                   |
 | `--tab-strip-elevation`                 | The size of the shadow for the tab strip     |
+| `--tab-strip-height`                    | Tab strip height                             |
 
 ---
 

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -49,6 +49,14 @@ gx-tab {
    * @prop --tab-caption-image-horizontal-margin: Tab caption image horizontal margin
    */
   --tab-caption-image-horizontal-margin: 2px;
+  /**
+   * @prop --tab-strip-background-color: Tab strip background color
+   */
+  --tab-strip-background-color: transparent;
+  /**
+   * @prop --tab-strip-height: Tab strip height
+   */
+  --tab-strip-height: auto;
 
   & > div {
     @include elevation();
@@ -65,6 +73,8 @@ gx-tab {
     .gx-nav-tabs {
       --elevation: var(--tab-strip-elevation);
       @include elevation();
+      background-color: var(--tab-strip-background-color);
+      height: var(--tab-strip-height);
 
       display: flex;
       flex-direction: row;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Fixed how background images are displayed in buttons
- Made canvas overflow hidden
- Fixed how images with no autogrow are rendered
- Forced dates to be displayed in single line in `gx-edit` when readonly
- Added support for tab strip height and back color through CSS variables
