### PR TITLE
Fix dependency to Swiper's type def

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@types/resize-observer-browser": "^0.1.3",
+    "@types/swiper": "^5.4.0",
     "bootstrap": "^4.3.1",
     "bootstrap.native": "^2.0.23",
     "lazysizes": "^5.1.0",
@@ -49,7 +50,6 @@
     "@stencil/sass": "^1.3.2",
     "@types/jest": "24.9.1",
     "@types/puppeteer": "1.19.0",
-    "@types/swiper": "^5.4.0",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.8.0",
     "eslint": "^6.6.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- It was configured as a dev dependency. Moved it to dependencies to avoid warnings in packages that use the library.