### PR TITLE
Fix buttons default style

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -23,11 +23,20 @@ gx-button {
     background-repeat: no-repeat;
     background-position: center center;
     background-size: contain;
+    max-width: 100%;
 
     & > img {
       height: var(--gx-button-image-size);
       width: var(--gx-button-image-size);
       object-fit: contain;
+    }
+
+    & > span {
+      display: block;
+      max-width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &:not(:disabled):not(.disabled) {

--- a/src/components/renders/bootstrap/button/button-render.tsx
+++ b/src/components/renders/bootstrap/button/button-render.tsx
@@ -48,6 +48,7 @@ export class ButtonRender implements Renderer {
         <button
           class={{
             btn: true,
+            "p-0": true,
             "btn-lg": button.size === "large",
             "btn-outline-secondary": true,
             "btn-sm": button.size === "small",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Buttons' text is shown in a single line. If there's overflow, and ellipsis is shown.
- Removed a default padding.
