### PR TITLE
Adjust canvas component to the size of its contents

### DIFF
--- a/src/components/canvas-cell/readme.md
+++ b/src/components/canvas-cell/readme.md
@@ -4,16 +4,28 @@ A cell for the [gx-canvas](../canvas/readme.md) component
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                                                                                                                                                                                                                                                                                                         | Type                            | Default     |
-| -------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------- |
-| `align`        | `align`         | Defines the horizontal aligmnent of the content of the cell.                                                                                                                                                                                                                                                                                                                                        | `"center" \| "left" \| "right"` | `"left"`    |
-| `overflowMode` | `overflow-mode` | This attribute defines how the control behaves when the content overflows.  \| Value    \| Details                                                     \| \| -------- \| ----------------------------------------------------------- \| \| `scroll` \| The overflowin content is hidden, but scrollbars are shown  \| \| `clip`   \| The overflowing content is hidden, without scrollbars       \| | `"clip" \| "scroll"`            | `undefined` |
-| `valign`       | `valign`        | Defines the vertical aligmnent of the content of the cell.                                                                                                                                                                                                                                                                                                                                          | `"bottom" \| "medium" \| "top"` | `"top"`     |
+| Property       | Attribute       | Description                                                                                                                                                                                                                                                                                                                        | Type                            | Default     |
+| -------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------- |
+| `align`        | `align`         | Defines the horizontal aligmnent of the content of the cell.                                                                                                                                                                                                                                                                       | `"center" \| "left" \| "right"` | `"left"`    |
+| `overflowMode` | `overflow-mode` | This attribute defines how the control behaves when the content overflows. \| Value \| Details \| \| -------- \| ----------------------------------------------------------- \| \| `scroll` \| The overflowin content is hidden, but scrollbars are shown \| \| `clip` \| The overflowing content is hidden, without scrollbars \| | `"clip" \| "scroll"`            | `undefined` |
+| `valign`       | `valign`        | Defines the vertical aligmnent of the content of the cell.                                                                                                                                                                                                                                                                         | `"bottom" \| "medium" \| "top"` | `"top"`     |
 
+## Dependencies
 
-----------------------------------------------
+### Used by
 
-*Built with [StencilJS](https://stenciljs.com/)*
+- [gx-grid-empty-indicator](../grid-empty-indicator)
+
+### Graph
+
+```mermaid
+graph TD;
+  gx-grid-empty-indicator --> gx-canvas-cell
+  style gx-canvas-cell fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/src/components/canvas/canvas.scss
+++ b/src/components/canvas/canvas.scss
@@ -4,5 +4,4 @@ gx-canvas {
   @include visibility(block);
 
   position: relative;
-  overflow: auto;
 }

--- a/src/components/canvas/readme.md
+++ b/src/components/canvas/readme.md
@@ -4,14 +4,12 @@ A container for creating absolute positioned layouts.
 
 <!-- Auto Generated Below -->
 
-
 ## Properties
 
-| Property        | Attribute        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Type                         | Default      |
-| --------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------ |
-| `disabled`      | `disabled`       | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).                                                                                                                                                                                                                                                                                                                           | `boolean`                    | `false`      |
-| `invisibleMode` | `invisible-mode` | This attribute lets you specify how this element will behave when hidden.  \| Value        \| Details                                                                     \| \| ------------ \| --------------------------------------------------------------------------- \| \| `keep-space` \| The element remains in the document flow, and it does occupy space.         \| \| `collapse`   \| The element is removed form the document flow, and it doesn't occupy space. \| | `"collapse" \| "keep-space"` | `"collapse"` |
-
+| Property        | Attribute        | Description                                                                                                                                                                                                                                                                                                                                                                                  | Type                         | Default      |
+| --------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------ |
+| `disabled`      | `disabled`       | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).                                                                                                                                                                                                                                     | `boolean`                    | `false`      |
+| `invisibleMode` | `invisible-mode` | This attribute lets you specify how this element will behave when hidden. \| Value \| Details \| \| ------------ \| --------------------------------------------------------------------------- \| \| `keep-space` \| The element remains in the document flow, and it does occupy space. \| \| `collapse` \| The element is removed form the document flow, and it doesn't occupy space. \| | `"collapse" \| "keep-space"` | `"collapse"` |
 
 ## Events
 
@@ -24,7 +22,20 @@ A container for creating absolute positioned layouts.
 | `swipeRight` | Emitted when the element is swiped right direction.     | `CustomEvent<any>` |
 | `swipeUp`    | Emitted when the element is swiped in upward direction. | `CustomEvent<any>` |
 
+## Dependencies
 
-----------------------------------------------
+### Used by
 
-*Built with [StencilJS](https://stenciljs.com/)*
+- [gx-grid-empty-indicator](../grid-empty-indicator)
+
+### Graph
+
+```mermaid
+graph TD;
+  gx-grid-empty-indicator --> gx-canvas
+  style gx-canvas fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are manually emulating `height: auto; width: auto;`. We have to do it manually because `gx-canvas-cell` components are absolutely positioned.
