### PR TITLE
issue with the selectionLayer fixed

### DIFF
--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -233,7 +233,7 @@ export class Map implements GxComponent {
     let i = 0;
     marker.remove();
     while (
-      i <= this.markersList.length &&
+      i < this.markersList.length &&
       this.markersList[i]._leaflet_id !== marker._leaflet_id
     ) {
       i++;
@@ -395,7 +395,9 @@ export class Map implements GxComponent {
   componentDidUpdate() {
     const maxZoom = this.checkForMaxZoom();
     this.setMapProvider();
-    this.fitBounds();
+    if (this.selectionLayer) {
+      this.fitBounds();
+    }
     this.map.setMaxZoom(maxZoom);
     this.userLocationChange.emit(this.userLocationCoords);
   }


### PR DESCRIPTION
## Issue
The error was caused by a mistake in the code when markers are deleted in the gxMap.
The `selectionLayer` feature uses a marker to point the center.

When any marker loads, it must be registered/saved by the map. And when a marker is deleted from the map, it must be deleted from the markers list.
To delete the marker obj from markers list, it must iterate in the list finding the instance. But, the conditional in the `while` was wrong!

## Fix
The solution was to fix a simple error in the `while` conditional. Going from `i <= markerList.length` to `i < markerList.length` to prevent the error of access to an undefined space.


#### _Additional Idea_
Can we improve the markerList array and convert it into a hashMap?
This way we would be able to access directly to the marker instance with the id as the hash key.

> _Example of saving new marker_ 
> ```javascript
> markersList.set(marker._leaflet_id, markerInstance)
> ```

> _Example of deleting marker_ 
> ```javascript
> markersList.delete(marker._leaflet_id)
> ```