### PR TITLE
Change the criteria for highlighting components

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -5,6 +5,7 @@ import {
   DisableableComponent,
   VisibilityComponent
 } from "../common/interfaces";
+import { makeHighlightable } from "../common/highlightable";
 
 @Component({
   shadow: false,
@@ -85,6 +86,10 @@ export class Button
 
   componentWillLoad() {
     this.renderer.componentWillLoad();
+  }
+
+  componentDidLoad() {
+    makeHighlightable(this.element);
   }
 
   render() {

--- a/src/components/common/highlightable.ts
+++ b/src/components/common/highlightable.ts
@@ -1,0 +1,49 @@
+const HIGHLIGHT_EVENT_NAME = "highlight";
+const UNHIGHTLIGHT_EVENT_NAME = "unhighlight";
+const HIGHLIGHT_CLASS_NAME = "gx-highlighted";
+let isSetup = false;
+
+export function makeHighlightable(element: HTMLElement) {
+  if (!isSetup) {
+    isSetup = true;
+    setup();
+  }
+
+  element.addEventListener(HIGHLIGHT_EVENT_NAME, (event: CustomEvent) => {
+    event.stopPropagation();
+    element.classList.add(HIGHLIGHT_CLASS_NAME);
+  });
+  element.addEventListener(UNHIGHTLIGHT_EVENT_NAME, (event: CustomEvent) => {
+    event.stopPropagation();
+    element.classList.remove(HIGHLIGHT_CLASS_NAME);
+  });
+}
+
+function setup() {
+  setupEvent("mousedown", "mouseup", "mousemove");
+  setupEvent("touchstart", "touchend", "touchmove");
+}
+
+function setupEvent(
+  startEventName: string,
+  endEventName: string,
+  moveEventName: string
+) {
+  document.body.addEventListener(startEventName, startEvent => {
+    fireCustomEvent(HIGHLIGHT_EVENT_NAME, startEvent.target as HTMLElement);
+    const mouseUpHandler = endEvent => {
+      fireCustomEvent(UNHIGHTLIGHT_EVENT_NAME, endEvent.target as HTMLElement);
+      document.body.removeEventListener(endEventName, mouseUpHandler);
+      document.body.removeEventListener(moveEventName, mouseUpHandler);
+    };
+    document.body.addEventListener(endEventName, mouseUpHandler);
+    document.body.addEventListener(moveEventName, mouseUpHandler);
+  });
+}
+
+function fireCustomEvent(eventName: string, element: HTMLElement) {
+  const highlightEvent = new CustomEvent(eventName, {
+    bubbles: true
+  });
+  element.dispatchEvent(highlightEvent);
+}

--- a/src/components/grid-base/grid-base-theming-mixins.scss
+++ b/src/components/grid-base/grid-base-theming-mixins.scss
@@ -22,7 +22,7 @@
   @extend #{$class};
 
   @if ($highlighted != null) {
-    &:active {
+    &.gx-highlighted {
       @extend #{$highlighted} !optional;
     }
   }
@@ -69,7 +69,7 @@
   @extend #{$class};
 
   @if ($highlighted != null) {
-    &:active,
+    &.gx-highlighted,
     &[data-gx-grid-highlighted] {
       @extend #{$highlighted} !optional;
     }

--- a/src/components/grid-base/grid-base.tsx
+++ b/src/components/grid-base/grid-base.tsx
@@ -1,4 +1,5 @@
 import { EventEmitter } from "@stencil/core";
+import { makeHighlightable } from "../common/highlightable";
 
 export interface GridBase {
   el: HTMLElement;
@@ -45,6 +46,10 @@ export interface GridBase {
 
 export class GridBaseHelper {
   static GRID_BASE_CLASSNAME = "gx-grid-base";
+
+  static init(element: HTMLElement) {
+    makeHighlightable(element);
+  }
 
   static hostData(cmp: GridBase) {
     return {

--- a/src/components/grid-fs/grid-fs.tsx
+++ b/src/components/grid-fs/grid-fs.tsx
@@ -98,6 +98,10 @@ export class GridFreeStyle
     }
   }
 
+  componentDidLoad() {
+    GridBaseHelper.init(this.el);
+  }
+
   render() {
     this.ensureViewPort();
     return (

--- a/src/components/grid-smart/grid-smart.tsx
+++ b/src/components/grid-smart/grid-smart.tsx
@@ -219,6 +219,7 @@ export class GridSmart
 
   componentDidLoad() {
     window.requestAnimationFrame(() => this.ensureSwiper());
+    GridBaseHelper.init(this.el);
   }
 
   componentDidUpdate() {

--- a/src/components/group/_group-theming-mixins.scss
+++ b/src/components/group/_group-theming-mixins.scss
@@ -10,16 +10,16 @@
   & > fieldset {
     @extend #{$class} !optional;
 
-    @if ($highlighted != null) {
-      &:active {
-        @extend #{$highlighted} !optional;
-      }
-    }
-
     @if ($caption != null) {
       & > legend {
         @extend #{$caption} !optional;
       }
+    }
+  }
+
+  @if ($highlighted != null) {
+    &.gx-highlighted > fieldset {
+      @extend #{$highlighted} !optional;
     }
   }
 }

--- a/src/components/group/group.tsx
+++ b/src/components/group/group.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Prop, h } from "@stencil/core";
+import { makeHighlightable } from "../common/highlightable";
 import { Component as GxComponent } from "../common/interfaces";
 @Component({
   shadow: false,
@@ -19,6 +20,10 @@ export class Group implements GxComponent {
    * if the content overflows.
    */
   @Prop() readonly autoGrow: boolean;
+
+  componentDidLoad() {
+    makeHighlightable(this.element);
+  }
 
   render() {
     return (

--- a/src/components/image/_image-theming-mixins.scss
+++ b/src/components/image/_image-theming-mixins.scss
@@ -15,9 +15,11 @@
 ) {
   img {
     @extend #{$class} !optional;
+  }
 
-    @if ($highlighted != null) {
-      &.gx-highlighted {
+  @if ($highlighted != null) {
+    &.gx-highlighted {
+      img {
         @extend #{$highlighted} !optional;
       }
     }

--- a/src/components/image/_image-theming-mixins.scss
+++ b/src/components/image/_image-theming-mixins.scss
@@ -17,7 +17,7 @@
     @extend #{$class} !optional;
 
     @if ($highlighted != null) {
-      &:active {
+      &.gx-highlighted {
         @extend #{$highlighted} !optional;
       }
     }

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -15,6 +15,7 @@ import {
   VisibilityComponent
 } from "../common/interfaces";
 import { cssVariablesWatcher } from "../common/css-variables-watcher";
+import { makeHighlightable } from "../common/highlightable";
 
 const LAZY_LOAD_CLASS = "gx-lazyload";
 const LAZY_LOADING_CLASS = "gx-lazyloading";
@@ -144,15 +145,21 @@ export class Image
       const img = event.target as HTMLImageElement;
       // Some image formats do not specify intrinsic dimensions. The naturalWidth property returns 0 in those cases.
       if (img.naturalWidth !== 0) {
-        this.width = `${
-          this.element.clientWidth > 0
-            ? img.naturalWidth > this.element.clientWidth
-              ? this.element.clientWidth
-              : null
-            : img.naturalWidth
-        }px`;
+        if (this.element.clientWidth > 0) {
+          if (img.naturalWidth > this.element.clientWidth) {
+            this.width = `${this.element.clientWidth}px`;
+          } else {
+            this.width = null;
+          }
+        } else {
+          this.width = `${img.naturalWidth}px`;
+        }
       }
     }
+  }
+
+  componentDidLoad() {
+    makeHighlightable(this.element.querySelector("img"));
   }
 
   disconnectedCallback() {

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -159,7 +159,7 @@ export class Image
   }
 
   componentDidLoad() {
-    makeHighlightable(this.element.querySelector("img"));
+    makeHighlightable(this.element);
   }
 
   disconnectedCallback() {

--- a/src/components/renders/bootstrap/button/_button-theming-mixins.scss
+++ b/src/components/renders/bootstrap/button/_button-theming-mixins.scss
@@ -16,9 +16,11 @@
 
       filter: brightness(85%);
     }
+  }
 
-    @if ($highlighted != null) {
-      &:not(:disabled):not(.disabled):active {
+  @if ($highlighted != null) {
+    &.gx-highlighted {
+      button:not(:disabled):not(.disabled) {
         @extend #{$highlighted} !optional;
       }
     }

--- a/src/components/tab-caption/_tab-caption-theming-mixins.scss
+++ b/src/components/tab-caption/_tab-caption-theming-mixins.scss
@@ -8,9 +8,11 @@
 @mixin gx-tab-caption($class, $highlighted: null) {
   a.gx-nav-link {
     @extend #{$class} !optional;
+  }
 
-    @if ($highlighted != null) {
-      &:active {
+  @if ($highlighted != null) {
+    &.gx-highlighted {
+      a.gx-nav-link {
         @extend #{$highlighted} !optional;
       }
     }

--- a/src/components/tab-caption/tab-caption.tsx
+++ b/src/components/tab-caption/tab-caption.tsx
@@ -17,6 +17,7 @@ import {
   imagePositionClass,
   hideMainImageWhenDisabledClass
 } from "../common/image-position";
+import { makeHighlightable } from "../common/highlightable";
 
 let autoTabId = 0;
 
@@ -83,6 +84,10 @@ export class TabCaption implements GxComponent, DisableableComponent {
     }
     this.hasDisabledImage =
       this.element.querySelector("[slot='disabled-image']") !== null;
+  }
+
+  componentDidLoad() {
+    makeHighlightable(this.element);
   }
 
   render() {

--- a/src/components/tab/_tab-theming-mixins.scss
+++ b/src/components/tab/_tab-theming-mixins.scss
@@ -16,7 +16,7 @@
   @extend #{$class} !optional;
 
   @if ($highlighted != null) {
-    &:active {
+    &.gx-highlighted {
       @extend #{$highlighted} !optional;
     }
   }

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -8,6 +8,7 @@ import {
   h,
   Host
 } from "@stencil/core";
+import { makeHighlightable } from "../common/highlightable";
 import {
   Component as GxComponent,
   VisibilityComponent
@@ -88,6 +89,7 @@ export class Tab implements GxComponent, VisibilityComponent {
   }
 
   componentDidLoad() {
+    makeHighlightable(this.element);
     this.linkTabs(true);
   }
 

--- a/src/components/table/_table-theming-mixins.scss
+++ b/src/components/table/_table-theming-mixins.scss
@@ -10,7 +10,7 @@
   @extend #{$class} !optional;
 
   @if ($highlighted != null) {
-    &:active {
+    &.gx-highlighted {
       @extend #{$highlighted} !optional;
     }
   }

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -7,6 +7,7 @@ import {
   h,
   Host
 } from "@stencil/core";
+import { makeHighlightable } from "../common/highlightable";
 import {
   Component as GxComponent,
   DisableableComponent,
@@ -88,6 +89,7 @@ export class Table
 
   componentDidLoad() {
     makeSwipeable(this);
+    makeHighlightable(this.element);
   }
 
   render() {

--- a/src/components/textblock/_textblock-theming-mixins.scss
+++ b/src/components/textblock/_textblock-theming-mixins.scss
@@ -26,9 +26,12 @@
   .content,
   .label-content {
     @extend #{$class} !optional;
+  }
 
-    @if ($highlighted != null) {
-      &:active {
+  @if ($highlighted != null) {
+    &.gx-highlighted {
+      .content,
+      .label-content {
         @extend #{$highlighted} !optional;
       }
     }

--- a/src/components/textblock/textblock.tsx
+++ b/src/components/textblock/textblock.tsx
@@ -7,6 +7,7 @@ import {
   State,
   h
 } from "@stencil/core";
+import { makeHighlightable } from "../common/highlightable";
 import {
   ClickableComponent,
   Component as GxComponent,
@@ -73,6 +74,10 @@ export class TextBlock
   private handleClick(event: UIEvent) {
     this.gxClick.emit(event);
     event.preventDefault();
+  }
+
+  componentDidLoad() {
+    makeHighlightable(this.element);
   }
 
   render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before this PR, we were styling highlighted components using the `:active` pseudo class. The problem with this approach was that the parent components would also get highlighted on mouse down.
This PR fixes that, adjusting to GeneXus UI criteria, and only setting the inner-most component as highlighted.
