### PR TITLE
Fix/gx radio group option

### DIFF
--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -59,6 +59,13 @@ export class RadioGroup
   @Prop() readonly name: string;
 
   /**
+   * This attribute indicates that the user cannot modify the value of the control.
+   * Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly)
+   * attribute for `input` elements.
+   */
+  @Prop() readonly readonly: boolean;
+
+  /**
    * The initial value of the control. Setting the value automatically selects
    * the corresponding radio option.
    */
@@ -166,7 +173,7 @@ export class RadioGroup
 
   setDisabled() {
     this.radios.forEach(radio => {
-      radio.disabled = this.disabled;
+      radio.disabled = this.disabled || this.readonly;
     });
   }
 

--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -66,6 +66,22 @@ gx-form-field {
     }
   }
 
+  .label-position-top {
+    flex-direction: column;
+  }
+
+  .label-position-right {
+    flex-direction: row-reverse;
+  }
+
+  .label-position-bottom {
+    flex-direction: column-reverse;
+  }
+
+  .label-position-left {
+    flex-direction: row;
+  }
+
   .label-left,
   .label-right {
     position: relative;
@@ -122,22 +138,6 @@ gx-form-field {
     display: flex;
     flex: 1;
     flex-wrap: wrap;
-  }
-
-  .label-position-top {
-    flex-direction: column;
-  }
-
-  .label-position-right {
-    flex-direction: row-reverse;
-  }
-
-  .label-position-bottom {
-    flex-direction: column-reverse;
-  }
-
-  .label-position-left {
-    flex-direction: row;
   }
 
   gx-checkbox {

--- a/src/components/renders/bootstrap/form-field/form-field-render.scss
+++ b/src/components/renders/bootstrap/form-field/form-field-render.scss
@@ -124,6 +124,22 @@ gx-form-field {
     flex-wrap: wrap;
   }
 
+  .label-position-top {
+    flex-direction: column;
+  }
+
+  .label-position-right {
+    flex-direction: row-reverse;
+  }
+
+  .label-position-bottom {
+    flex-direction: column-reverse;
+  }
+
+  .label-position-left {
+    flex-direction: row;
+  }
+
   gx-checkbox {
     .custom-checkbox {
       padding-top: calc(1.375rem + 1px);

--- a/src/components/renders/bootstrap/form-field/form-field-render.tsx
+++ b/src/components/renders/bootstrap/form-field/form-field-render.tsx
@@ -17,6 +17,14 @@ export class FormFieldRender implements Renderer {
     right: "label-right",
     top: "label-top"
   };
+  private flexDirection = {
+    bottom: "column-reverse",
+    float: "",
+    left: "row",
+    none: "",
+    right: "row-reverse",
+    top: "column"
+  };
 
   private INNER_CONTROL_WIDTH_BY_LABEL_POSITION = {
     bottom: "field-label-bottom",
@@ -55,6 +63,8 @@ export class FormFieldRender implements Renderer {
     return (
       !formField.labelPosition ||
       formField.labelPosition === "top" ||
+      formField.labelPosition === "right" ||
+      formField.labelPosition === "bottom" ||
       formField.labelPosition === "left" ||
       formField.labelPosition === "none"
     );
@@ -90,7 +100,12 @@ export class FormFieldRender implements Renderer {
     );
     return (
       <div class="form-group mb-0" aria-labelledby={labelId} role="group">
-        <div class="radio-group no-gutters">
+        <div
+          class="radio-group no-gutters"
+          style={{
+            "flex-direction": this.flexDirection[this.component.labelPosition]
+          }}
+        >
           {renderLabel && renderLabelBefore ? label : null}
           <div class={this.getInnerControlContainerClass()}>{slot}</div>
           {renderLabel && !renderLabelBefore ? label : null}

--- a/src/components/renders/bootstrap/form-field/form-field-render.tsx
+++ b/src/components/renders/bootstrap/form-field/form-field-render.tsx
@@ -98,12 +98,19 @@ export class FormFieldRender implements Renderer {
         <div class="label-content">{this.component.labelCaption}</div>
       </div>
     );
+    const labelPositionClassName = `label-position-${this.component.labelPosition}`;
+    const isValidLabelPosition =
+      this.component.labelPosition === "top" ||
+      this.component.labelPosition === "right" ||
+      this.component.labelPosition === "bottom" ||
+      this.component.labelPosition === "left";
     return (
       <div class="form-group mb-0" aria-labelledby={labelId} role="group">
         <div
-          class="radio-group no-gutters"
-          style={{
-            "flex-direction": this.flexDirection[this.component.labelPosition]
+          class={{
+            "radio-group": true,
+            "no-gutters": true,
+            [labelPositionClassName]: isValidLabelPosition
           }}
         >
           {renderLabel && renderLabelBefore ? label : null}

--- a/src/components/renders/bootstrap/form-field/form-field-render.tsx
+++ b/src/components/renders/bootstrap/form-field/form-field-render.tsx
@@ -17,14 +17,6 @@ export class FormFieldRender implements Renderer {
     right: "label-right",
     top: "label-top"
   };
-  private flexDirection = {
-    bottom: "column-reverse",
-    float: "",
-    left: "row",
-    none: "",
-    right: "row-reverse",
-    top: "column"
-  };
 
   private INNER_CONTROL_WIDTH_BY_LABEL_POSITION = {
     bottom: "field-label-bottom",


### PR DESCRIPTION
### Issue
When you assign a `gxRadioGroup` as `read-only`, the radio-buttons still available and clickable.
Another issue was about the label position, but this bug was in `gxFormField`. You assign the `label-position` but the label only show properly when `label-position = "left"`

### Fixes
Unlike gxEdit, if we take out the input (radiobutton) and left only the label, it will be a bit confusing. That is why I decided to show as "disabled" when readioButton is `read-only`
And for the _label position_ issue, I decided to use the `flex-direction` to order the label and the radioButtons

### Additional Idea
Perhaps we should set a CSS class in the `.sass` file and use that class instead of inline style. What do you think?