### PR TITLE
Generate React wrappers for library components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -529,6 +529,12 @@
         "tsutils": "^3.0.0"
       }
     },
+    "@stencil/react-output-target": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.0.9.tgz",
+      "integrity": "sha512-t2sSkm/VGftBqewK47eZonaHIXW7CYWlsDy6Ln4jqNVpr93CuPWkg7rsnPiZrJrU1NBuTgA0hC2xoRcAJVm7Sw==",
+      "dev": true
+    },
     "@stencil/sass": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.3.2.tgz",
@@ -724,8 +730,7 @@
     "@types/swiper": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@types/swiper/-/swiper-5.4.0.tgz",
-      "integrity": "sha512-+MpoI6aa8iEC5rvIDh8W1ZWq/F5iQNU2JFOFyfNYQl0nBxuLo8kHcoO2VyZR7ft22nRkQitdPMof+FIAX9xHnw==",
-      "dev": true
+      "integrity": "sha512-+MpoI6aa8iEC5rvIDh8W1ZWq/F5iQNU2JFOFyfNYQl0nBxuLo8kHcoO2VyZR7ft22nRkQitdPMof+FIAX9xHnw=="
     },
     "@types/yargs": {
       "version": "13.0.11",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@stencil/core": "^1.16.4",
     "@stencil/eslint-plugin": "^0.2.1",
+    "@stencil/react-output-target": "0.0.9",
     "@stencil/sass": "^1.3.2",
     "@types/jest": "24.9.1",
     "@types/puppeteer": "1.19.0",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,5 +1,6 @@
 import { Config } from "@stencil/core";
 import { sass } from "@stencil/sass";
+import { reactOutputTarget } from "@stencil/react-output-target";
 
 export const config: Config = {
   bundles: [
@@ -57,7 +58,11 @@ export const config: Config = {
     {
       type: "www",
       serviceWorker: null
-    }
+    },
+    reactOutputTarget({
+      componentCorePackage: "@genexus/web-controls-library",
+      proxiesFile: "../react-web-controls-library/src/components.ts"
+    })
   ],
   plugins: [sass()]
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Generate React wrappers for the library components automatically using `@stencil/react-output-target`
- This assumes there's a sibling directory that contains the React components project, called `react-web-controls-library`.
