### PR TITLE
Improved font resizing in circle gauge type and minor fixes.

### DIFF
--- a/src/components/gauge/gauge.scss
+++ b/src/components/gauge/gauge.scss
@@ -71,6 +71,8 @@ gx-gauge {
   */
   --indicator-line-background-color: rgba(44, 44, 44, 1);
 
+  $transitionConfig: 0.3s ease;
+
   @mixin flex-centered {
     display: flex;
     justify-content: center;
@@ -116,12 +118,13 @@ gx-gauge {
       overflow: hidden;
       position: absolute;
       width: calc(100%);
-      background-color: rgba(0, 0, 0, 0.1);
+      background-color: rgba(0, 0, 0, 0.2);
       .range {
         height: 100%;
         position: absolute;
         // box-shadow: var(--gauge-ranges-box-shadow);
         @include flex-centered;
+        transition: $transitionConfig;
       }
     }
 
@@ -129,11 +132,11 @@ gx-gauge {
       transform: translateY(-4px);
       position: absolute;
       z-index: 1;
+      transition: $transitionConfig;
       .indicator {
         content: "";
         border-left-style: solid;
         border-left-color: var(--indicator-line-background-color);
-        transform: translateX(-50%);
         display: block;
         background-color: var(--indicator-line-background-color);
       }
@@ -149,6 +152,7 @@ gx-gauge {
         margin-top: 1px;
         position: absolute;
         filter: brightness(0.5);
+        transition: $transitionConfig;
       }
     }
   }
@@ -161,6 +165,9 @@ gx-gauge {
     svg {
       width: 100%;
       height: 100%;
+      circle {
+        transition: $transitionConfig;
+      }
     }
     .gauge {
       position: absolute;
@@ -179,6 +186,7 @@ gx-gauge {
   .circularMarker {
     width: 100%;
     position: absolute;
+    transition: $transitionConfig;
 
     .circularIndicator {
       background-color: var(--indicator-circle-background-color);

--- a/src/components/gauge/gauge.scss
+++ b/src/components/gauge/gauge.scss
@@ -78,8 +78,10 @@ gx-gauge {
   }
 
   @include flex-centered;
+  align-items: center;
   flex-wrap: wrap;
   position: relative;
+  width: 100%;
 
   .gaugeContainerLine {
     position: relative;
@@ -156,10 +158,9 @@ gx-gauge {
     height: 100%;
     width: 100%;
     align-items: center;
-    .gaugeContainer {
-      @include flex-centered;
-      z-index: 0;
-      position: absolute;
+    svg {
+      width: 100%;
+      height: 100%;
     }
     .gauge {
       position: absolute;
@@ -176,7 +177,7 @@ gx-gauge {
   }
 
   .circularMarker {
-    height: 100%;
+    width: 100%;
     position: absolute;
 
     .circularIndicator {

--- a/src/components/gauge/gauge.tsx
+++ b/src/components/gauge/gauge.tsx
@@ -217,14 +217,12 @@ export class Gauge implements GxComponent {
         for (const entry of entries) {
           const elem = entry.contentRect;
           const minimumSize = Math.min(elem.width, elem.height);
-          const value = this.element.querySelector(
-            "div.svgContainer div.gauge div span.current-value"
-          );
+          const value = this.element.querySelector(".current-value");
 
-          const marker = this.element.querySelector("div.circularMarker");
+          const marker = this.element.querySelector(".circularMarker");
 
           const markerIndicator = this.element.querySelector(
-            "div.circularMarker div.circularIndicator"
+            ".circularIndicator"
           );
 
           value.setAttribute("style", `font-size: ${minimumSize / 2.5}px`);

--- a/src/components/gauge/gauge.tsx
+++ b/src/components/gauge/gauge.tsx
@@ -205,10 +205,28 @@ export class Gauge implements GxComponent {
       positionInGauge += (360 * childRanges[i].amount) / this.totalAmount;
     }
 
+    let parent = this.element.parentElement;
+    let maxSize;
+
+    // It iterates from the leaf to the root node searching for size
+    // constraints and stops when finds the first constraint
+    while (parent != null && (maxSize === undefined || maxSize === undefined)) {
+      maxSize =
+        parent.attributes.getNamedItem("max-height") != null
+          ? parent.attributes.getNamedItem("max-height").value
+          : undefined;
+
+      parent = parent.parentElement;
+    }
+
+    // Remove the last 2 characters ('px')
+    if (maxSize !== undefined) {
+      maxSize = maxSize.toString().substring(0, maxSize.length - 2);
+    }
     return (
       <Host>
         <div class="svgContainer">
-          <svg width="100%" height="100%" viewBox="0 0 100 100">
+          <svg viewBox="0 0 100 100">
             <circle
               r={radius}
               cx="50%"
@@ -219,13 +237,6 @@ export class Gauge implements GxComponent {
             />
             {svgRanges}
           </svg>
-          <div
-            class="gaugeContainer"
-            style={{
-              height: `${this.minimumSize}px`,
-              width: `${this.minimumSize}px`
-            }}
-          />
           {this.showValue && (
             <div class="gauge">
               <div>
@@ -233,9 +244,13 @@ export class Gauge implements GxComponent {
                   <span
                     class="current-value"
                     style={{
-                      "font-size": `${(this.minimumSize /
-                        document.body.offsetWidth) *
-                        30}vw`
+                      "font-size":
+                        maxSize !== undefined
+                          ? `clamp(0px, ${(this.minimumSize /
+                              document.body.offsetWidth) *
+                              30}vw, ${maxSize / (10 / 3)}px)`
+                          : `${(this.minimumSize / document.body.offsetWidth) *
+                              30}vw`
                     }}
                   >{`${this.value}`}</span>
                 )}
@@ -251,15 +266,18 @@ export class Gauge implements GxComponent {
                 this.calcPercentage() == 100
                   ? "rotate(359.5deg)"
                   : `rotate(${this.calcPercentage() *
-                      ONE_PERCENT_OF_CIRCLE_DREGREE}deg)`
+                      ONE_PERCENT_OF_CIRCLE_DREGREE +
+                      90}deg)`,
+              "max-width": maxSize !== undefined ? `${maxSize}px` : "auto"
             }}
           >
             <div
               class="circularIndicator"
               style={{
-                width: `${this.element.offsetWidth /
-                  document.body.offsetWidth}vw`,
-                height: `calc(${this.thickness}% + 2%)`
+                width: `calc(${this.thickness}% + 2%)`,
+                height: `${this.minimumSize / document.body.offsetWidth}vw`,
+                "max-height":
+                  maxSize !== undefined ? `${maxSize / 100}px` : "auto"
               }}
             />
           </div>
@@ -321,7 +339,7 @@ export class Gauge implements GxComponent {
                     ? 100
                     : this.calcPercentage()
                 }%`,
-                transform: `translate(-${valueOffset}%, -22px)` // 22px, 38px
+                transform: `translate(-${valueOffset}%, -28px)` // 22px, 38px
               }}
             >
               {this.value}

--- a/src/components/gauge/gauge.tsx
+++ b/src/components/gauge/gauge.tsx
@@ -116,10 +116,8 @@ export class Gauge implements GxComponent {
   private calcPercentage(): number {
     return this.value <= this.minValue
       ? 0
-      : this.value >= this.maxValueAux
-      ? 100
       : ((this.value - this.minValue) * 100) /
-        (this.maxValueAux - this.minValue);
+          (this.maxValueAux - this.minValue);
   }
 
   private addCircleRanges(
@@ -130,7 +128,8 @@ export class Gauge implements GxComponent {
     const FULL_CIRCLE_RADIANS = 2 * Math.PI;
     const ROTATION_FIX = -90;
     const circleLength = FULL_CIRCLE_RADIANS * radius;
-    const valuePercentage = (100 * amount) / this.totalAmount;
+    const range = this.maxValueAux - this.minValue;
+    const valuePercentage = amount / range;
     return (
       <circle
         class="circle-range"
@@ -138,8 +137,7 @@ export class Gauge implements GxComponent {
         cx="50%"
         cy="50%"
         stroke={color}
-        stroke-dasharray={`${circleLength *
-          (valuePercentage / 100)}, ${circleLength}`}
+        stroke-dasharray={`${circleLength * valuePercentage}, ${circleLength}`}
         fill="none"
         transform={`rotate(${position + ROTATION_FIX} 50,50)`}
         data-amount={amount}
@@ -149,19 +147,21 @@ export class Gauge implements GxComponent {
   }
 
   private addLineRanges({ amount, color }, position: number): any {
+    const range = this.maxValueAux - this.minValue;
     return (
       <div
         class="range"
         style={{
           "background-color": color,
           "margin-left": `${position}%`,
-          width: `${(amount * 100) / this.totalAmount}%`
+          width: `${(amount * 100) / range}%`
         }}
       />
     );
   }
 
   private addLineRangesLabels({ amount, color, name }, position: number): any {
+    const range = this.maxValueAux - this.minValue;
     return (
       <span
         class="rangeName"
@@ -174,7 +174,7 @@ export class Gauge implements GxComponent {
               ? 0
               : this.element.offsetHeight / 4 + this.thickness / 3
           }px)`,
-          width: `${(amount * 100) / this.totalAmount}%`
+          width: `${(amount * 100) / range}%`
         }}
       >
         {name}
@@ -189,40 +189,62 @@ export class Gauge implements GxComponent {
     const svgRanges = [];
     const ONE_PERCENT_OF_CIRCLE_DREGREE = 3.6;
     const radius = FULL_CIRCLE_RADIO - this.thickness / 2;
-
+    const ROTATION_FIX = 90; // Used to correct the rotation
     this.totalAmount = 0;
     for (let i = childRanges.length - 1; i >= 0; i--) {
       this.totalAmount += childRanges[i].amount;
     }
     this.updateMaxValueAux();
 
+    const range = this.maxValueAux - this.minValue;
     let positionInGauge = 0;
     for (let i = 0; i < childRanges.length; i++) {
       svgRanges.push(
         this.addCircleRanges(childRanges[i], positionInGauge, radius)
       );
 
-      positionInGauge += (360 * childRanges[i].amount) / this.totalAmount;
+      positionInGauge += (360 * childRanges[i].amount) / range;
     }
 
-    let parent = this.element.parentElement;
-    let maxSize;
+    const rotation =
+      this.calcPercentage() == 100
+        ? `rotate(${359.5 + ROTATION_FIX}deg)`
+        : `rotate(${this.calcPercentage() * ONE_PERCENT_OF_CIRCLE_DREGREE +
+            ROTATION_FIX}deg)`;
 
-    // It iterates from the leaf to the root node searching for size
-    // constraints and stops when finds the first constraint
-    while (parent != null && (maxSize === undefined || maxSize === undefined)) {
-      maxSize =
-        parent.attributes.getNamedItem("max-height") != null
-          ? parent.attributes.getNamedItem("max-height").value
-          : undefined;
+    if (this.showValue) {
+      const ro = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          const elem = entry.contentRect;
+          const minimumSize = Math.min(elem.width, elem.height);
+          const value = this.element.querySelector(
+            "div.svgContainer div.gauge div span.current-value"
+          );
 
-      parent = parent.parentElement;
+          const marker = this.element.querySelector("div.circularMarker");
+
+          const markerIndicator = this.element.querySelector(
+            "div.circularMarker div.circularIndicator"
+          );
+
+          value.setAttribute("style", `font-size: ${minimumSize / 2.5}px`);
+
+          marker.setAttribute(
+            "style",
+            `transform: ${rotation}; max-width: ${minimumSize}px`
+          );
+
+          markerIndicator.setAttribute(
+            "style",
+            `width: ${this.thickness + 2}%; height: ${minimumSize / 100}px`
+          );
+        }
+      });
+
+      // Observe the gauge to resize the font and the value marker
+      ro.observe(this.element);
     }
 
-    // Remove the last 2 characters ('px')
-    if (maxSize !== undefined) {
-      maxSize = maxSize.toString().substring(0, maxSize.length - 2);
-    }
     return (
       <Host>
         <div class="svgContainer">
@@ -241,45 +263,15 @@ export class Gauge implements GxComponent {
             <div class="gauge">
               <div>
                 {this.showValue && (
-                  <span
-                    class="current-value"
-                    style={{
-                      "font-size":
-                        maxSize !== undefined
-                          ? `clamp(0px, ${(this.minimumSize /
-                              document.body.offsetWidth) *
-                              30}vw, ${maxSize / (10 / 3)}px)`
-                          : `${(this.minimumSize / document.body.offsetWidth) *
-                              30}vw`
-                    }}
-                  >{`${this.value}`}</span>
+                  <span class="current-value">{`${this.value}`}</span>
                 )}
               </div>
             </div>
           )}
         </div>
         {this.showValue && (
-          <div
-            class="circularMarker"
-            style={{
-              transform:
-                this.calcPercentage() == 100
-                  ? "rotate(359.5deg)"
-                  : `rotate(${this.calcPercentage() *
-                      ONE_PERCENT_OF_CIRCLE_DREGREE +
-                      90}deg)`,
-              "max-width": maxSize !== undefined ? `${maxSize}px` : "auto"
-            }}
-          >
-            <div
-              class="circularIndicator"
-              style={{
-                width: `calc(${this.thickness}% + 2%)`,
-                height: `${this.minimumSize / document.body.offsetWidth}vw`,
-                "max-height":
-                  maxSize !== undefined ? `${maxSize / 100}px` : "auto"
-              }}
-            />
+          <div class="circularMarker">
+            <div class="circularIndicator" />
           </div>
         )}
       </Host>
@@ -306,6 +298,7 @@ export class Gauge implements GxComponent {
         ? 72
         : 50;
 
+    const range = this.maxValueAux - this.minValue;
     let positionInGauge = 0;
 
     for (let i = 0; i < childRanges.length; i++) {
@@ -314,7 +307,7 @@ export class Gauge implements GxComponent {
         this.addLineRangesLabels(childRanges[i], positionInGauge)
       );
 
-      positionInGauge += (100 * childRanges[i].amount) / this.totalAmount;
+      positionInGauge += (100 * childRanges[i].amount) / range;
     }
     return (
       <div
@@ -362,14 +355,8 @@ export class Gauge implements GxComponent {
             class="marker"
             style={{
               "margin-left": `${
-                this.value <= this.minValue
-                  ? `${this.element.offsetWidth /
-                      (document.body.offsetWidth * 2)}vw`
-                  : this.value >= this.maxValueAux
-                  ? `calc(100% - ${this.element.offsetWidth /
-                      (document.body.offsetWidth * 2)}%)`
-                  : `${this.calcPercentage()}%`
-              }`
+                this.calcPercentage() >= 100 ? 100 : this.calcPercentage()
+              }%`
             }}
           >
             <div
@@ -377,7 +364,13 @@ export class Gauge implements GxComponent {
               style={{
                 height: `${this.thickness * 2 + 4}px`,
                 "border-left-width": `${this.element.offsetWidth /
-                  document.body.offsetWidth}vw`
+                  document.body.offsetWidth}vw`,
+                transform:
+                  this.calcPercentage() > 0 && this.calcPercentage() < 100
+                    ? "translateX(-50%)"
+                    : this.calcPercentage() >= 100
+                    ? "translateX(-100%)"
+                    : "translateX(0%)"
               }}
             />
           </span>


### PR DESCRIPTION
Main change:
   - In the circle gauge type, solved an issue where the font scaling kept growing even if the container size has reached a maximum size. Now the font (and the value marker) has a maximum size if in the container is defined the attribute "max-height".

Minor changes:
   - Some fixed css were move to the corresponding css file (previous line 211 in .tsx).

   - Removed a div container with the corresponding css selector, due to they don't had any use (previous lines 222 - 228 in .tsx and 159 - 162 in css).

   - In the line gauge type, corrected the position of the value label (previous line 324 in .tsx).

   - Fixed an issue where the line gauge type were not resizing according to the container width (added line 84 in css file).