### PR TITLE
Checkbox readonly property implementation

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -46,6 +46,13 @@ export class CheckBox implements FormComponent {
   @Prop() readonly disabled = false;
 
   /**
+   * This attribute indicates that the user cannot modify the value of the control.
+   * Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly)
+   * attribute for `input` elements.
+   */
+  @Prop() readonly readonly = false;
+
+  /**
    * Specifies the label of the checkbox.
    */
   @Prop() readonly caption: string;

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -80,6 +80,7 @@ $gx-xsmall-breakpoint: 768px;
 
 @mixin scss-custom-option-control() {
   $transitionConfig: 0.15s ease-in-out;
+  $disabledColor: #a5a8aac0;
 
   --option-checked-color: #007bff;
 
@@ -121,13 +122,15 @@ $gx-xsmall-breakpoint: 768px;
           }
         }
 
-        &:active:not(:checked):not(:disabled) ~ .custom-option {
-          border-color: var(--option-highlight-border-color);
-          background-color: var(--option-highlight-border-color);
-        }
+        &:active:not(:disabled) {
+          &:not(:checked) ~ .custom-option {
+            border-color: var(--option-highlight-border-color);
+            background-color: var(--option-highlight-border-color);
+          }
 
-        &:active:not(:disabled) ~ .custom-option {
-          filter: brightness(85%);
+          & ~ .custom-option {
+            filter: brightness(85%);
+          }
         }
 
         &:focus ~ .custom-option {
@@ -135,8 +138,7 @@ $gx-xsmall-breakpoint: 768px;
         }
 
         &:disabled ~ .custom-option {
-          background-color: #e9ecef;
-          opacity: 1;
+          background-color: $disabledColor;
         }
       }
 

--- a/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
+++ b/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
@@ -64,7 +64,7 @@ export class CheckBoxRender implements Renderer {
       "aria-disabled": checkbox.disabled ? "true" : undefined,
       class: this.getCssClasses(),
       "data-native-element": "",
-      disabled: checkbox.disabled,
+      disabled: checkbox.disabled || checkbox.readonly,
       id: this.inputId,
       onInput: this.handleChange
     };
@@ -78,7 +78,9 @@ export class CheckBoxRender implements Renderer {
       <div data-readonly="">
         <div
           class="container"
-          data-part={!checkbox.disabled ? "option-control" : ""}
+          data-part={
+            !checkbox.disabled && !checkbox.readonly ? "option-control" : ""
+          }
         >
           <div class="option-container">
             <input


### PR DESCRIPTION
In GeneXus, there is a readonly property for the Check Box Attribute, but this property doesn't do anything with the Angular generator.