### PR TITLE
`lineClamp` refactoring

### DIFF
--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -70,7 +70,6 @@ $gx-xsmall-breakpoint: 768px;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: var(--max-lines);
   overflow: hidden;
-  max-height: var(--max-height);
 }
 
 // Used to measure the line height, in order to make the lines clampable

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -22,6 +22,9 @@ export function debounce(
   };
 }
 
+/*  This functions overrides a method adding calls before (`before()`) and
+    after (`after()`) 
+*/
 export function overrideMethod(
   component: Component,
   methodName: string,

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -40,7 +40,7 @@ export class Edit implements FormComponent, HighlightableComponent {
       }
     ]);
 
-    makeLinesClampable(this, "[data-readonly]", ".line-measuring");
+    makeLinesClampable(this, ".readonly-content-container", ".line-measuring");
   }
 
   private renderer: EditRender;
@@ -193,7 +193,6 @@ export class Edit implements FormComponent, HighlightableComponent {
   @Prop() readonly inner: string = "";
 
   @State() maxLines = 0;
-  @State() maxHeight = 0;
 
   /**
    * The `change` event is emitted when a change to the element's value is

--- a/src/components/renders/bootstrap/edit/edit-render.scss
+++ b/src/components/renders/bootstrap/edit/edit-render.scss
@@ -136,12 +136,29 @@ gx-edit {
   // This applies when the gx-edit is readonly
   [data-readonly] {
     @include margins;
-    white-space: break-spaces;
     display: flex;
     flex: 1;
+    position: relative;
+    white-space: break-spaces;
 
-    .readonly-content {
-      margin: 0;
+    .readonly-content-container {
+      display: flex;
+      align-items: inherit;
+      flex: 1;
+      position: relative;
+      height: 100%;
+      overflow: hidden;
+
+      .readonly-content {
+        position: absolute;
+        width: 100%;
+        margin: 0;
+
+        // Used when autoGrow = true
+        &.relative {
+          position: relative;
+        }
+      }
     }
   }
 

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -198,29 +198,30 @@ export class EditRender implements Renderer {
     const ReadonlyTag = this.getReadonlyTagByFontCategory() as any;
 
     return [
-      <gx-bootstrap />,
       edit.readonly && edit.format == "Text" && (
         <div data-readonly="">
-          <ReadonlyTag
-            key="readonly"
-            class={{
-              "readonly-content": true,
-              "gx-line-clamp": this.shouldClampLines()
-            }}
-            style={
-              this.shouldClampLines() && {
-                "--max-lines": edit.maxLines.toString(),
-                "--max-height": `${edit.maxHeight}px`
+          <div class="readonly-content-container">
+            <ReadonlyTag
+              key="readonly"
+              class={{
+                "readonly-content": true,
+                "gx-line-clamp": this.component.lineClamp,
+                relative: !this.component.lineClamp
+              }}
+              style={
+                this.component.lineClamp && {
+                  "--max-lines": edit.maxLines.toString()
+                }
               }
-            }
-          >
-            {edit.lineClamp && (
-              <div class="line-measuring" aria-hidden>
-                {"A"}
-              </div>
-            )}
-            {this.getReadonlyContent(edit, edit.value)}
-          </ReadonlyTag>
+            >
+              {edit.lineClamp && (
+                <div class="line-measuring" aria-hidden>
+                  {"A"}
+                </div>
+              )}
+              {this.getReadonlyContent(edit, edit.value)}
+            </ReadonlyTag>
+          </div>
         </div>
       ),
       editableElement
@@ -233,9 +234,5 @@ export class EditRender implements Renderer {
       return "span";
     }
     return tag;
-  }
-
-  private shouldClampLines() {
-    return this.component.lineClamp && this.component.maxLines > 0;
   }
 }

--- a/src/components/textblock/textblock.scss
+++ b/src/components/textblock/textblock.scss
@@ -8,8 +8,10 @@
         text-align: $text-align;
       }
 
-      @if ($align-items != null) {
-        align-items: $align-items;
+      & > .readonly-content-container {
+        @if ($align-items != null) {
+          align-items: $align-items;
+        }
       }
     }
   }
@@ -28,9 +30,22 @@ gx-textblock {
     display: flex;
     flex: 1;
 
-    & > .text-container {
-      @include elevation();
+    & > .readonly-content-container {
+      display: flex;
       flex: 1;
+      position: relative;
+      overflow: hidden;
+
+      & > .text-container {
+        @include elevation();
+        position: absolute;
+        width: 100%;
+
+        // Used when autoGrow = true
+        &.relative {
+          position: relative;
+        }
+      }
     }
 
     &.html-content {

--- a/src/components/textblock/textblock.tsx
+++ b/src/components/textblock/textblock.tsx
@@ -23,7 +23,7 @@ export class TextBlock
     LineClampComponent,
     HighlightableComponent {
   constructor() {
-    makeLinesClampable(this, ".content", ".line-measuring");
+    makeLinesClampable(this, ".readonly-content-container", ".line-measuring");
   }
 
   @Element() element: HTMLGxTextblockElement;
@@ -77,7 +77,6 @@ export class TextBlock
   @Prop() readonly inner: string = "";
 
   @State() maxLines = 0;
-  @State() maxHeight = 0;
 
   @Listen("click", { capture: true })
   handleClick(event: UIEvent) {
@@ -95,26 +94,25 @@ export class TextBlock
   render() {
     if (this.format == "Text") {
       const body = (
-        <div
-          class={{
-            content: true,
-            "text-content": true,
-            "gx-line-clamp": this.shouldClampLines()
-          }}
-          style={
-            this.shouldClampLines() && {
-              "--max-lines": this.maxLines.toString(),
-              "--max-height": `${this.maxHeight}px`
-            }
-          }
-        >
-          {this.lineClamp && (
-            <div class="line-measuring" aria-hidden>
-              {"A"}
+        <div class="content text-content">
+          <div class="readonly-content-container">
+            <div
+              class={{
+                "text-container": true,
+                "gx-line-clamp": this.lineClamp,
+                relative: !this.lineClamp
+              }}
+              style={{
+                "--max-lines": this.lineClamp ? this.maxLines.toString() : "0"
+              }}
+            >
+              {this.lineClamp && (
+                <div class="line-measuring" aria-hidden>
+                  {"A"}
+                </div>
+              )}
+              <slot />
             </div>
-          )}
-          <div class="text-container">
-            <slot />
           </div>
         </div>
       );
@@ -131,9 +129,5 @@ export class TextBlock
         </div>
       );
     }
-  }
-
-  private shouldClampLines() {
-    return this.lineClamp && this.maxLines > 0;
   }
 }


### PR DESCRIPTION
- The complexity of the calculations in the `lineClamp` algorithm has been minimized.

- The `lineClamp` algorithm will no longer set the `max-height` property of the components.

- Now, the components will be sized to the maximum available height and the `lineClamp` algorithm will only set the maximum number of lines (`maxLines`) available to display.

- Now, the `lineClamp` algorithm will no longer reset the `maxLines` available to display, instead, the algorithm will always keep the last value of `maxLines` and will update this value if the `content-container` changes his height or the font changes its height.

Those changes has been applied to the gx-edit and gx-textblock controls.