### PR TITLE
Added support to customize the margin of the button image

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -2,6 +2,25 @@
 @import "../common/_image-position";
 @import "../renders/bootstrap/button/button-render";
 
+// Used to set the margin for different types of images
+@mixin imageMargin() {
+  &.gx-image-position {
+    &--before,
+    &--after,
+    &--above,
+    &--below,
+    &--behind {
+      [slot="main-image"],
+      [slot="disabled-image"] {
+        margin: var(--gx-button-image-margin-top)
+          var(--gx-button-image-margin-right)
+          var(--gx-button-image-margin-bottom)
+          var(--gx-button-image-margin-left);
+      }
+    }
+  }
+}
+
 // The width property does not apply when the navbar is the main container
 gx-table-cell {
   & > gx-button {
@@ -18,9 +37,43 @@ gx-canvas-cell {
 }
 
 gx-button {
+  /**
+   * @prop --gx-button-image-size: Button image size
+   * (16px by default)
+   */
+  --gx-button-image-size: 16px;
+
+  /**
+   * @prop --gx-button-image-margin-top: Button image top margin
+   * (0px by default)
+   */
+  --gx-button-image-margin-top: 0px;
+
+  /**
+   * @prop --gx-button-image-margin-right: Button image right margin
+   * (0px by default)
+   */
+  --gx-button-image-margin-right: 0px;
+
+  /**
+   * @prop --gx-button-image-margin-bottom: Button image bottom margin
+   * (0px by default)
+   */
+  --gx-button-image-margin-bottom: 0px;
+
+  /**
+   * @prop --gx-button-image-margin-left: Button image left margin
+   * (0px by default)
+   */
+  --gx-button-image-margin-left: 0px;
+
   @include visibility(inline-flex);
 
-  --gx-button-image-size: 16px;
+  // Used to decide the position of the image
+  @include imagePosition("button.gx-button", ".gx-button--disabled");
+
+  @include imageMargin();
+
   margin-top: var(--margin-top);
   margin-right: var(--margin-right);
   margin-bottom: var(--margin-bottom);
@@ -66,6 +119,4 @@ gx-button {
       }
     }
   }
-
-  @include imagePosition("button.gx-button", ".gx-button--disabled");
 }

--- a/src/components/button/readme.md
+++ b/src/components/button/readme.md
@@ -29,10 +29,36 @@ If the main image is the only image specified, it will be displayed both when th
 | --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ------------ |
 | `cssClass`      | `css-class`      | A CSS class to set as the inner `input` element class.                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `string`                                                | `undefined`  |
 | `disabled`      | `disabled`       | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event). If a disabled image has been specified, it will be shown, hiding the base image (if specified).                                                                                                                                                                                                                                               | `boolean`                                               | `false`      |
+| `height`        | `height`         | This attribute lets you specify the height.                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `string`                                                | `""`         |
 | `highlightable` | `highlightable`  | True to highlight control when an action is fired.                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `boolean`                                               | `false`      |
 | `imagePosition` | `image-position` | This attribute lets you specify the relative location of the image to the text. \| Value \| Details \| \| -------- \| ------------------------------------------------------- \| \| `above` \| The image is located above the text. \| \| `before` \| The image is located before the text, in the same line. \| \| `after` \| The image is located after the text, in the same line. \| \| `below` \| The image is located below the text. \| \| `behind` \| The image is located behind the text. \| | `"above" \| "after" \| "before" \| "behind" \| "below"` | `"above"`    |
 | `invisibleMode` | `invisible-mode` | This attribute lets you specify how this element will behave when hidden. \| Value \| Details \| \| ------------ \| --------------------------------------------------------------------------- \| \| `keep-space` \| The element remains in the document flow, and it does occupy space. \| \| `collapse` \| The element is removed form the document flow, and it doesn't occupy space. \|                                                                                                           | `"collapse" \| "keep-space"`                            | `"collapse"` |
 | `size`          | `size`           | This attribute lets you specify the size of the button. \| Value \| Details \| \| -------- \| ------------------------------------------------------- \| \| `large` \| Large sized button. \| \| `normal` \| Standard sized button. \| \| `small` \| Small sized button. \|                                                                                                                                                                                                                            | `"large" \| "normal" \| "small"`                        | `"normal"`   |
+| `width`         | `width`          | This attribute lets you specify the width.                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `string`                                                | `""`         |
+
+## CSS Custom Properties
+
+| Name                              | Description                                 |
+| --------------------------------- | ------------------------------------------- |
+| `--gx-button-image-margin-bottom` | Button image bottom margin (0px by default) |
+| `--gx-button-image-margin-left`   | Button image left margin (0px by default)   |
+| `--gx-button-image-margin-right`  | Button image right margin (0px by default)  |
+| `--gx-button-image-margin-top`    | Button image top margin (0px by default)    |
+| `--gx-button-image-size`          | Button image size (16px by default)         |
+
+## Dependencies
+
+### Used by
+
+- [gx-image-picker](../image-picker)
+
+### Graph
+
+```mermaid
+graph TD;
+  gx-image-picker --> gx-button
+  style gx-button fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ---
 


### PR DESCRIPTION
Now, there is the possibility to customize the margin of the `gx-button` image with the following variables:
- `--gx-button-image-margin-top: 0px`; Button image top margin

- `--gx-button-image-margin-right: 0px`; Button image right margin

- `--gx-button-image-margin-bottom: 0px`; Button image bottom margin

- `--gx-button-image-margin-left: 0px`; Button image left margin

These variables apply to the main and disabled image, and also apply to `before`, `after`, `above`, `below` and `behind` value of image position.