### PR TITLE
Fixes for range values in the `date`, `datetime-local` and `time` types

### DIFF
--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -163,6 +163,7 @@ export class Edit implements FormComponent, HighlightableComponent {
     | "search"
     | "tel"
     | "text"
+    | "time"
     | "url" = "text";
 
   /**

--- a/src/components/renders/bootstrap/edit/edit-render.tsx
+++ b/src/components/renders/bootstrap/edit/edit-render.tsx
@@ -119,10 +119,33 @@ export class EditRender implements Renderer {
       "data-native-element": "",
       disabled: edit.disabled,
       id: this.inputId,
+
+      // We limit the year to 4 digits
+      max:
+        edit.type === "datetime-local"
+          ? "9999-12-31T23:59:59"
+          : edit.type === "date"
+          ? "9999-12-31"
+          : undefined,
+
+      // We extend the minimum value of the date
+      min:
+        edit.type === "datetime-local"
+          ? "0001-01-01T00:00:00"
+          : edit.type === "date"
+          ? "0001-01-01"
+          : undefined,
+
       onChange: this.handleChange,
-      onInput: valueChangingHandler,
       onClick: edit.disabled ? null : this.stopPropagation,
-      placeholder: edit.placeholder
+      onInput: valueChangingHandler,
+      placeholder: edit.placeholder,
+      step:
+        edit.type === "date" ||
+        edit.type === "datetime-local" ||
+        edit.type === "time"
+          ? "1"
+          : undefined
     };
 
     // This will be displayed at the end


### PR DESCRIPTION
Changes we propose in this PR:
- When the type is `date` or `datetime-local`, we set the maximum date to `9999-12-31`.

- When the type is `date` or `datetime-local`, we set the minimum date to `0001-01-01`.

- When the type is `date`, `datetime-local` or `time`, we set the `step="1"` property to specifies the interval between legal numbers. Without this property, we can not use seconds precision.

- Also, we add `time` type, because we use it in Angular but it was not specified in the `gx-edit` control.