### PR TITLE
Improved support for Firefox Web browser and fix for `gx-caption` height when the `gx-tab-page` is empty

### DIFF
--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -141,7 +141,7 @@ gx-tab {
 
     // Used to show the captions in the top position
     &[data-position="top"] {
-      grid-template-rows: fit-content(50%) auto;
+      grid-template-rows: minmax(auto, max-content);
 
       .gx-nav-tabs {
         @include elevation();
@@ -156,7 +156,7 @@ gx-tab {
 
     // Used to show the captions in the bottom position
     &[data-position="bottom"] {
-      grid-template-rows: auto fit-content(50%);
+      grid-template-rows: auto minmax(auto, max-content);
 
       .gx-nav-tabs {
         @include elevation(top);


### PR DESCRIPTION
**Changes we propose in this PR**:
- Improved support in Firefox Web Browser. In some case scenario, where the Tab Page has `autoGrow = True`, two vertical scrollbars were still appearing when the Tab Page content overflowed; one in the Tab Page and another in the body of the application. This is no longer the case, now only the body scrollbar will appear.

-  When the parent container of the `gx-tab` has low values of `height` (`50px` for example) and the Tab Page of the currently selected `gx-caption` is empty, the `gx-caption` was just using the 50% of the parent container height. This is no longer the case, now when the Tab Page of the `gx-caption` is empty, the `gx-caption` will grow to fit the height of its content or to reach its parent container height.

issue: 92591
issue: 92588