### PR TITLE
Fixes for U7

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -98,6 +98,13 @@ gx-button {
     background-size: contain;
     max-width: 100%;
 
+    /*  If the button caption is empty, the inner image will stretch to the
+        container size
+    */
+    &.empty-caption {
+      --gx-button-image-size: 100%;
+    }
+
     & > img {
       height: var(--gx-button-image-size);
       width: var(--gx-button-image-size);

--- a/src/components/renders/bootstrap/button/button-render.tsx
+++ b/src/components/renders/bootstrap/button/button-render.tsx
@@ -57,7 +57,10 @@ export class ButtonRender implements Renderer {
             "btn-lg": button.size === "large",
             "btn-sm": button.size === "small",
             "gx-button": true,
-            [button.cssClass]: !!button.cssClass
+            [button.cssClass]: !!button.cssClass,
+
+            // Strings with only white spaces are taken as null captions
+            "empty-caption": button.element.textContent.trim() === ""
           }}
           disabled={button.disabled}
           onClick={this.handleClick}

--- a/src/components/textblock/textblock.scss
+++ b/src/components/textblock/textblock.scss
@@ -3,11 +3,12 @@
 
 // Used to horizontally and vertically align the text
 @mixin alignment($text-align: null, $align-items: null) {
-  .content.text-content {
+  .content {
     @if ($text-align != null) {
       text-align: $text-align;
     }
 
+    .html-container,
     .readonly-content-container {
       @if ($align-items != null) {
         align-items: $align-items;


### PR DESCRIPTION
**Changes we propose in this PR**:
- Added support for html alignment (horizontal and vertical) in `gx-textblock`.

- When the caption is empty in the `gx-button` the inner image will be stretched to the container size.

issue: 92600
issue: 92597