### PR TITLE
Fix margin inheritance

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -74,16 +74,21 @@ gx-button {
 
   @include imageMargin();
 
-  margin-top: var(--margin-top);
-  margin-right: var(--margin-right);
-  margin-bottom: var(--margin-bottom);
-  margin-left: var(--margin-left);
+  @include reset-variables();
+  @include container-margins();
   height: var(--height);
 
   vertical-align: middle;
 
   &.stretch-height {
     align-self: stretch;
+  }
+
+  /*  If the button caption is empty, the inner image will stretch to the
+      container size
+  */
+  &.empty-caption {
+    --gx-button-image-size: 100%;
   }
 
   & > button.gx-button {
@@ -97,13 +102,6 @@ gx-button {
     background-position: center center;
     background-size: contain;
     max-width: 100%;
-
-    /*  If the button caption is empty, the inner image will stretch to the
-        container size
-    */
-    &.empty-caption {
-      --gx-button-image-size: 100%;
-    }
 
     & > img {
       height: var(--gx-button-image-size);

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -7,8 +7,5 @@ gx-checkbox {
 
   --option-border-radius: 25%;
 
-  margin-top: var(--margin-top, 0);
-  margin-right: var(--margin-right, 0);
-  margin-bottom: var(--margin-bottom, 0);
-  margin-left: var(--margin-left, 0);
+  @include container-margins();
 }

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -58,6 +58,15 @@ $gx-xsmall-breakpoint: 768px;
   margin-left: var(--margin-left, 0);
 }
 
+@mixin reset-variables() {
+  --margin-top: initial;
+  --margin-right: initial;
+  --margin-bottom: initial;
+  --margin-left: initial;
+  --width: initial;
+  --height: initial;
+}
+
 @mixin elevation($shadowPosition: bottom) {
   @if $shadowPosition == bottom {
     box-shadow: 0

--- a/src/components/form-field/form-field.scss
+++ b/src/components/form-field/form-field.scss
@@ -2,6 +2,7 @@
 @import "../renders/bootstrap/form-field/form-field-render";
 
 gx-form-field {
+  @include reset-variables();
   @include visibility(flex);
 
   justify-self: stretch;

--- a/src/components/gauge/gauge.scss
+++ b/src/components/gauge/gauge.scss
@@ -157,10 +157,7 @@ gx-gauge {
   display: flex;
   position: relative;
   width: 100%;
-  margin-top: var(--margin-top, 0);
-  margin-right: var(--margin-right, 0);
-  margin-bottom: var(--margin-bottom, 0);
-  margin-left: var(--margin-left, 0);
+  @include container-margins();
   transition: background-color $transition-delay, border-color $transition-delay;
 
   .line-gauge-container {

--- a/src/components/image-picker/image-picker.scss
+++ b/src/components/image-picker/image-picker.scss
@@ -1,4 +1,8 @@
+@import "../common/_base";
+
 gx-image-picker {
+  @include container-margins();
+
   display: flex;
   flex: 1;
   pointer-events: none;

--- a/src/components/image-picker/image-picker.tsx
+++ b/src/components/image-picker/image-picker.tsx
@@ -275,7 +275,7 @@ export class ImagePicker implements GxComponent {
 
   render() {
     return (
-      <Host>
+      <Host data-part="container">
         <div class="click-capture" onClick={this.stopPropagation}>
           <gx-image
             class="image-viewer-image"

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -3,6 +3,7 @@
 gx-image {
   --elevation: 0;
 
+  @include reset-variables();
   @include visibility(inline-flex);
 
   justify-content: stretch;
@@ -12,11 +13,7 @@ gx-image {
   &.gx-img-no-auto-grow {
     width: var(--width);
     height: var(--height);
-    margin-top: var(--margin-top);
-    margin-right: var(--margin-right);
-    margin-bottom: var(--margin-bottom);
-    margin-left: var(--margin-left);
-
+    @include container-margins();
     position: relative;
 
     & > img {
@@ -35,10 +32,7 @@ gx-image {
     & > img {
       width: var(--width);
       height: var(--height);
-      margin-top: var(--margin-top);
-      margin-right: var(--margin-right);
-      margin-bottom: var(--margin-bottom);
-      margin-left: var(--margin-left);
+      @include container-margins();
 
       max-height: calc(
         100% - var(--margin-top, 0px) - var(--margin-bottom, 0px)

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -2,11 +2,7 @@
 
 gx-radio-group {
   @include visibility(flex);
-
-  margin-top: var(--margin-top, 0);
-  margin-right: var(--margin-right, 0);
-  margin-bottom: var(--margin-bottom, 0);
-  margin-left: var(--margin-left, 0);
+  @include container-margins();
 
   &[direction="vertical"] {
     flex-direction: column;

--- a/src/components/renders/bootstrap/button/button-render.tsx
+++ b/src/components/renders/bootstrap/button/button-render.tsx
@@ -42,7 +42,10 @@ export class ButtonRender implements Renderer {
           [imagePositionClass(button.imagePosition)]: true,
           [hideMainImageWhenDisabledClass]:
             button.disabled && this.hasDisabledImage,
-          ["stretch-height"]: button.height === ""
+          ["stretch-height"]: button.height === "",
+
+          // Strings with only white spaces are taken as null captions
+          "empty-caption": button.element.textContent.trim() === ""
         }}
         style={{
           "--width": button.width === "" ? "100%" : button.width,
@@ -57,10 +60,7 @@ export class ButtonRender implements Renderer {
             "btn-lg": button.size === "large",
             "btn-sm": button.size === "small",
             "gx-button": true,
-            [button.cssClass]: !!button.cssClass,
-
-            // Strings with only white spaces are taken as null captions
-            "empty-caption": button.element.textContent.trim() === ""
+            [button.cssClass]: !!button.cssClass
           }}
           disabled={button.disabled}
           onClick={this.handleClick}

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -3,6 +3,7 @@
 gx-table {
   --elevation: 0;
 
+  @include reset-variables();
   @include container-margins();
   @include elevation();
   @include visibility(grid);

--- a/src/components/textblock/textblock.scss
+++ b/src/components/textblock/textblock.scss
@@ -34,6 +34,7 @@ gx-textblock {
   // Default alignment which supports RTL
   @include alignment(start, flex-start);
 
+  @include reset-variables();
   @include container-margins();
   @include visibility(inline-flex);
   flex: 1;


### PR DESCRIPTION
**Changes we propose in this PR**:
- Fix variable inheritance from the parent container.

- Fix `--gx-button-image-size` variable not working in DSO when `gx-button` caption was empty.

- Added support for customize `gx-image-picker` control.

issue: 92593