### PR TITLE
Fix for fixed `padding` when there is no close button

### DIFF
--- a/src/components/renders/bootstrap/message/message-render.tsx
+++ b/src/components/renders/bootstrap/message/message-render.tsx
@@ -24,7 +24,7 @@ export class MessageRender implements Renderer {
     return {
       alert: true,
       [`${typeClass}`]: true,
-      "alert-dismissible": true,
+      "alert-dismissible": this.component.showCloseButton,
       fade: true
     };
   }


### PR DESCRIPTION
Now, the padding in the message text will be set correctly if the close button is displayed.

issue: 92646