### PR TITLE
Animate gauge loading

### DIFF
--- a/src/components/gauge/gauge.scss
+++ b/src/components/gauge/gauge.scss
@@ -31,6 +31,13 @@ gx-gauge {
   --stroke-linecap: initial;
 
   /**
+  * @prop --stroke-animation-duration:
+   * Sets the duration of the stroke transition animation the first time the component is loaded.
+   * (1s by default)
+  */
+  --stroke-animation-duration: 1s;
+
+  /**
   * @prop --value-text-color:
    * Define the color of the value text in `line` gauge type.
    * (rgba(44, 44, 44, 1) by default)
@@ -292,12 +299,44 @@ gx-gauge {
           stroke-linecap: var(--stroke-linecap, initial);
           transition: stroke $transition-delay,
             stroke-dasharray $transition-delay;
+
+          // Animates the first load of the ranges
+          animation: delay-animation
+              calc(var(--child-number) * var(--stroke-animation-duration)),
+            loading-animation var(--stroke-animation-duration) ease-in-out
+              calc(var(--child-number) * var(--stroke-animation-duration));
         }
 
         .background-circle {
           fill: none;
           stroke: var(--empty-range-background-color);
           transition: stroke $transition-delay;
+        }
+
+        /*  Useful when the circle gauge has at least 2 childs. 
+            In each child, c, it sets a delay of c * --stroke-animation-duration
+            to keep the stroke-dasharray at the starting position.
+        */
+        @keyframes delay-animation {
+          0% {
+            stroke-linecap: initial;
+            stroke-dasharray: var(--stroke-dasharray-initial);
+          }
+
+          100% {
+            stroke-linecap: initial;
+            stroke-dasharray: var(--stroke-dasharray-initial);
+          }
+        }
+
+        @keyframes loading-animation {
+          0% {
+            stroke-dasharray: var(--stroke-dasharray-initial);
+          }
+
+          100% {
+            stroke-dasharray: var(--stroke-dasharray);
+          }
         }
       }
 

--- a/src/components/gauge/gauge.scss
+++ b/src/components/gauge/gauge.scss
@@ -118,6 +118,38 @@ gx-gauge {
     }
   }
 
+  /*  Useful when the line gauge has at least 2 childs. 
+      In each child, c, it sets a delay of c * --stroke-animation-duration
+      to keep the stroke-dasharray at the starting position.
+  */
+  @keyframes delay-line-animation {
+    0% {
+      width: 0;
+    }
+
+    100% {
+      width: 0;
+    }
+  }
+
+  @keyframes loading-line-animation {
+    0% {
+      width: 0;
+    }
+
+    100% {
+      width: var(--range-width);
+    }
+  }
+
+  // Animates the first load of the ranges in the line gauge type
+  @mixin animate-loading-of-line-gauge-childs {
+    animation: delay-line-animation
+        calc(var(--child-number) * var(--stroke-animation-duration)),
+      loading-line-animation var(--stroke-animation-duration) ease-in-out
+        calc(var(--child-number) * var(--stroke-animation-duration));
+  }
+
   // This mixin is used to adjust the range labels based on the fontSize value
   @mixin labels-container(
     $align-items: center,
@@ -144,9 +176,14 @@ gx-gauge {
           @include flex-centered;
           position: absolute;
           line-height: 1.125em;
+          width: var(--range-width);
           max-height: 100%;
           filter: brightness(0.5);
           text-align: center;
+          overflow: hidden;
+
+          // Animates the first load of the ranges
+          @include animate-loading-of-line-gauge-childs;
 
           @if $transition == null {
             transition: height $transition-delay, width $transition-delay,
@@ -227,9 +264,13 @@ gx-gauge {
 
         .range {
           @include flex-centered;
+          width: var(--range-width);
           height: 100%;
           position: absolute;
           transition: width $transition-delay;
+
+          // Animates the first load of the ranges
+          @include animate-loading-of-line-gauge-childs;
         }
 
         @include labels-container;

--- a/src/components/gauge/gauge.scss
+++ b/src/components/gauge/gauge.scss
@@ -118,11 +118,37 @@ gx-gauge {
     }
   }
 
+  /*  Useful when the circle gauge has at least 2 childs. 
+      In each child, c, it sets a delay of c * --stroke-animation-duration
+      to keep the stroke-dasharray at the starting position.
+  */
+  @keyframes delay-animation-circle {
+    0% {
+      stroke-linecap: initial;
+      stroke-dasharray: var(--stroke-dasharray-initial);
+    }
+
+    100% {
+      stroke-linecap: initial;
+      stroke-dasharray: var(--stroke-dasharray-initial);
+    }
+  }
+
+  @keyframes loading-animation-circle {
+    0% {
+      stroke-dasharray: var(--stroke-dasharray-initial);
+    }
+
+    100% {
+      stroke-dasharray: var(--stroke-dasharray);
+    }
+  }
+
   /*  Useful when the line gauge has at least 2 childs. 
       In each child, c, it sets a delay of c * --stroke-animation-duration
       to keep the stroke-dasharray at the starting position.
   */
-  @keyframes delay-line-animation {
+  @keyframes delay-animation-line {
     0% {
       width: 0;
     }
@@ -132,7 +158,7 @@ gx-gauge {
     }
   }
 
-  @keyframes loading-line-animation {
+  @keyframes loading-animation-line {
     0% {
       width: 0;
     }
@@ -144,9 +170,9 @@ gx-gauge {
 
   // Animates the first load of the ranges in the line gauge type
   @mixin animate-loading-of-line-gauge-childs {
-    animation: delay-line-animation
+    animation: delay-animation-line
         calc(var(--child-number) * var(--stroke-animation-duration)),
-      loading-line-animation var(--stroke-animation-duration) ease-in-out
+      loading-animation-line var(--stroke-animation-duration) ease-in-out
         calc(var(--child-number) * var(--stroke-animation-duration));
   }
 
@@ -342,9 +368,10 @@ gx-gauge {
             stroke-dasharray $transition-delay;
 
           // Animates the first load of the ranges
-          animation: delay-animation
+          animation: delay-animation-circle
               calc(var(--child-number) * var(--stroke-animation-duration)),
-            loading-animation var(--stroke-animation-duration) ease-in-out
+            loading-animation-circle var(--stroke-animation-duration)
+              ease-in-out
               calc(var(--child-number) * var(--stroke-animation-duration));
         }
 
@@ -352,32 +379,6 @@ gx-gauge {
           fill: none;
           stroke: var(--empty-range-background-color);
           transition: stroke $transition-delay;
-        }
-
-        /*  Useful when the circle gauge has at least 2 childs. 
-            In each child, c, it sets a delay of c * --stroke-animation-duration
-            to keep the stroke-dasharray at the starting position.
-        */
-        @keyframes delay-animation {
-          0% {
-            stroke-linecap: initial;
-            stroke-dasharray: var(--stroke-dasharray-initial);
-          }
-
-          100% {
-            stroke-linecap: initial;
-            stroke-dasharray: var(--stroke-dasharray-initial);
-          }
-        }
-
-        @keyframes loading-animation {
-          0% {
-            stroke-dasharray: var(--stroke-dasharray-initial);
-          }
-
-          100% {
-            stroke-dasharray: var(--stroke-dasharray);
-          }
         }
       }
 

--- a/src/components/gauge/gauge.tsx
+++ b/src/components/gauge/gauge.tsx
@@ -356,7 +356,8 @@ export class Gauge implements GxComponent {
   private addCircleRanges(
     { amount, color },
     position: number,
-    radius: number
+    radius: number,
+    childNumber: string // Identifies the number of child to animate it at the start
   ): any {
     const FULL_CIRCLE_RADIANS = 2 * Math.PI;
     const ROTATION_FIX = -90;
@@ -374,6 +375,12 @@ export class Gauge implements GxComponent {
         transform={`rotate(${position + ROTATION_FIX} 50,50)`}
         data-amount={amount}
         stroke-width={`${this.calcThickness()}%`}
+        style={{
+          "--child-number": childNumber,
+          "--stroke-dasharray-initial": `0, ${circleLength}`,
+          "--stroke-dasharray": `${circleLength *
+            valuePercentage}, ${circleLength}`
+        }}
       />
     );
   }
@@ -428,7 +435,12 @@ export class Gauge implements GxComponent {
     let positionInGauge = 0;
     for (let i = 0; i < childRanges.length; i++) {
       svgRanges.push(
-        this.addCircleRanges(childRanges[i], positionInGauge, radius)
+        this.addCircleRanges(
+          childRanges[i],
+          positionInGauge,
+          radius,
+          i.toString()
+        )
       );
 
       positionInGauge += (360 * childRanges[i].amount) / range;

--- a/src/components/gauge/gauge.tsx
+++ b/src/components/gauge/gauge.tsx
@@ -385,7 +385,11 @@ export class Gauge implements GxComponent {
     );
   }
 
-  private addLineRanges({ amount, color }, position: number): any {
+  private addLineRanges(
+    { amount, color },
+    position: number,
+    childNumber: string // Identifies the number of child to animate it at the start
+  ): any {
     const range = this.maxValueAux - this.minValue;
     return (
       <div
@@ -393,13 +397,18 @@ export class Gauge implements GxComponent {
         style={{
           "background-color": color,
           "margin-left": `${position}%`,
-          width: `${(amount * 100) / range}%`
+          "--child-number": childNumber,
+          "--range-width": `${(amount * 100) / range}%`
         }}
       />
     );
   }
 
-  private addLineRangesLabels({ amount, color, name }, position: number): any {
+  private addLineRangesLabels(
+    { amount, color, name },
+    position: number,
+    childNumber: string // Identifies the number of child to animate it at the start
+  ): any {
     const range = this.maxValueAux - this.minValue;
 
     return (
@@ -408,7 +417,8 @@ export class Gauge implements GxComponent {
         style={{
           "margin-left": `${position}%`,
           color: color,
-          width: `${(amount * 100) / range}%`
+          "--child-number": childNumber,
+          "--range-width": `${(amount * 100) / range}%`
         }}
       >
         {name}
@@ -513,9 +523,11 @@ export class Gauge implements GxComponent {
     let positionInGauge = 0;
 
     for (let i = 0; i < childRanges.length; i++) {
-      divRanges.push(this.addLineRanges(childRanges[i], positionInGauge));
+      divRanges.push(
+        this.addLineRanges(childRanges[i], positionInGauge, i.toString())
+      );
       divRangesLabel.push(
-        this.addLineRangesLabels(childRanges[i], positionInGauge)
+        this.addLineRangesLabels(childRanges[i], positionInGauge, i.toString())
       );
 
       positionInGauge += (100 * childRanges[i].amount) / range;

--- a/src/components/gauge/readme.md
+++ b/src/components/gauge/readme.md
@@ -44,16 +44,20 @@ Use `gx-gauge-range` element to set the number of ranges.
 
 ## CSS Custom Properties
 
-| Name                           | Description                                                                                  |
-| ------------------------------ | -------------------------------------------------------------------------------------------- |
-| `--center-circle-text-color`   | Define the color of the center text in `circle` gauge type. (rgba(44, 44, 44, 1) by default) |
-| `--gauge-border-radius`        | Define the border radius of gauge in `line` gauge type. (25px by default)                    |
-| `--marker-color`               | Define the background color and border color of the marker. (rgba(44, 44, 44, 1) by default) |
-| `--max-value-background-color` | Set the color of maximum value display background. (rgba(44, 44, 44, 1) by default)          |
-| `--max-value-text-color`       | Set the color of maximum value display text. (rgba(255, 255, 255, 0.8) by default)           |
-| `--min-max-text-size`          | Set the size of min and max values display text. (1.5em by default)                          |
-| `--min-value-background-color` | Set the color of minimum value display background. (rgba(44, 44, 44, 1) by default)          |
-| `--min-value-text-color`       | Set the color of minimum value display text. (rgba(255, 255, 255, 0.8) by default)           |
+| Name                                  | Description                                                                                                      |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--center-circle-background-color`    | Define the color of the center background text in `circle` gauge type. (rgba(255, 255, 255, 0) by default)       |
+| `--center-circle-text-color`          | Define the color of the center text in `circle` gauge type. (rgba(44, 44, 44, 1) by default)                     |
+| `--indicator-circle-background-color` | Define the color of the background value indicator in `circle` gauge type. (rgba(44, 44, 44, 1) by default)      |
+| `--indicator-line-background-color`   | Set the color of background value indicator in `line` gauge type. (rgba(44, 44, 44, 1) by default)               |
+| `--max-value-background-color`        | Set the color of maximum value display background in `line` gauge type. (rgba(255, 255, 255, 0.800) by default)  |
+| `--max-value-text-color`              | Set the color of maximum value display text in `line` gauge type. (rgba(40, 40, 40, 0.8) by default)             |
+| `--min-value-background-color`        | Set the color of minimum value display background in `line` gauge type. (rgba(255, 255, 255, 0.8000) by default) |
+| `--min-value-text-color`              | Set the color of minimum value display text in `line` gauge type. (rgba(40, 40, 40, 0.8) by default)             |
+| `--stroke-animation-duration`         | Sets the duration of the stroke transition animation the first time the component is loaded. (1s by default)     |
+| `--stroke-linecap`                    | Defines the shape to be used at the end of open subpaths when they are stroked. (initial by default)             |
+| `--value-text-background-color`       | Define the background-color of the value text in `line` gauge type. (rgba(255, 255, 255, 0.800) by default)      |
+| `--value-text-color`                  | Define the color of the value text in `line` gauge type. (rgba(44, 44, 44, 1) by default)                        |
 
 ---
 


### PR DESCRIPTION
**Changes we propuse in this PR**:

Add animation to the first load of the gauge childs. In this case, each child will be animated when the `gx-gauge` loads for the first time. 
- The first child will animate with a delay of `0` and an animation duration of `--stroke-animation-duration`

- The second child will animate with a delay of `--stroke-animation-duration` and an animation duration of `--stroke-animation-duration`

- The third child will animate with a delay of `2 * --stroke-animation-duration` and an animation duration of `--stroke-animation-duration`

- And so it goes on.

This creates a feeling of "incremental loading" in the gauge ranges.

The `--stroke-animation-duration: 1s` variable sets the duration of the stroke transition animation the first time the `gx-gauge` is loaded.

issue: 92821