### PR TITLE
Fixes for empty text in `grid-base` and auto-grow in `gx-grid-smar-css`

### DIFF
--- a/src/components/grid-base/grid-base.scss
+++ b/src/components/grid-base/grid-base.scss
@@ -15,6 +15,7 @@ $gridContentSelector: "& > *[slot='grid-content']:not(virtual-scroller), & > * >
 
   & > .grid-empty-placeholder > [slot="grid-content-empty"] {
     flex: 1;
+    align-self: stretch;
   }
 }
 

--- a/src/components/grid-smart-css/grid-smart-css.scss
+++ b/src/components/grid-smart-css/grid-smart-css.scss
@@ -85,6 +85,16 @@ gx-grid-smart-css {
 /*
   Vertical Orientation
 */
+
+/*  This ensures that the rows will only set their height based on the height
+    of the content.
+*/
+gx-grid-smart-css[direction="vertical"] {
+  & > div {
+    grid-auto-rows: var(--gx-table-row-autogrow);
+  }
+}
+
 gx-grid-smart-css[direction="vertical"] {
   #{$gridContentSelector} {
     & > gx-grid-smart-cell[relative-size] {


### PR DESCRIPTION
**Changes we propose in this PR**:
- Fix empty grid container not using all available height.

- Fix grid rows that were scaling more than the height of their content.

The first change applies to all types of grid and the second change applies to `gx-grid-smart-css`.

issue: 92991
issue: 92993
