### PR TITLE
Accessibility improves for `gx-button`

### DIFF
--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -45,3 +45,25 @@ export function overrideMethod(
     }
   };
 }
+
+export function getFileNameWithoutExtension(filePath: string) {
+  let lastSlashIndex = filePath.lastIndexOf("/");
+
+  // If the function is call in the same folder of the file
+  if (lastSlashIndex === -1) {
+    lastSlashIndex = 0;
+  }
+
+  // We store the fileName that could have extension (+1 removes the last slash)
+  const fileName = filePath.substring(lastSlashIndex + 1);
+
+  const extensionIndex = fileName.lastIndexOf(".");
+
+  // If the file does not have extension
+  if (extensionIndex === -1) {
+    return fileName;
+  }
+
+  // Returns the name between the last "/" and the last "." of the `fileName`
+  return fileName.substring(0, extensionIndex);
+}

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -47,15 +47,18 @@ export function overrideMethod(
 }
 
 export function getFileNameWithoutExtension(filePath: string) {
-  let lastSlashIndex = filePath.lastIndexOf("/");
+  /*  If the function is called in the same folder as the file, 
+      lastIndexOf("/") might return -1, but since we add 1 to the result, the
+      value of fileNameStartIndex will be 0.
 
-  // If the function is call in the same folder of the file
-  if (lastSlashIndex === -1) {
-    lastSlashIndex = 0;
-  }
+      If lastIndexOf("/") >= 0, it means that filePath has at least one "/" and
+      adding 1 to the result of the function will return the index where the
+      fileName starts.
+  */
+  const fileNameStartIndex = filePath.lastIndexOf("/") + 1;
 
-  // We store the fileName that could have extension (+1 removes the last slash)
-  const fileName = filePath.substring(lastSlashIndex + 1);
+  // We store the fileName that could have extension
+  const fileName = filePath.substring(fileNameStartIndex);
 
   const extensionIndex = fileName.lastIndexOf(".");
 

--- a/src/components/renders/bootstrap/button/button-render.tsx
+++ b/src/components/renders/bootstrap/button/button-render.tsx
@@ -6,6 +6,7 @@ import {
   imagePositionClass,
   hideMainImageWhenDisabledClass
 } from "../../../common/image-position";
+import { getFileNameWithoutExtension } from "../../../common/utils";
 
 export class ButtonRender implements Renderer {
   constructor(private component: Button, handlers: { handleClick }) {
@@ -24,13 +25,23 @@ export class ButtonRender implements Renderer {
   render(slots: { default; disabledImage; mainImage }) {
     const button = this.component;
 
-    // Main image and disabled image are set an empty alt as they are decorative images.
+    // True if the button does not have any text
+    const isEmptyCaption = button.element.textContent.trim() === "";
+
+    /*  Main image and disabled image are set with an empty alt as they are
+        decorative images, but if the button has no caption, the alt property
+        will take the name of the image.
+    */
     const images = button.element.querySelectorAll(
       "[slot='main-image'], [slot='disabled-image']"
     );
+
     Array.from(images).forEach((img: HTMLImageElement) => {
       if (!img.alt) {
-        img.setAttribute("alt", "");
+        // The src image property always contains a path to the image file
+        const alt = isEmptyCaption ? getFileNameWithoutExtension(img.src) : "";
+
+        img.setAttribute("alt", alt);
       }
     });
 
@@ -45,7 +56,7 @@ export class ButtonRender implements Renderer {
           ["stretch-height"]: button.height === "",
 
           // Strings with only white spaces are taken as null captions
-          "empty-caption": button.element.textContent.trim() === ""
+          "empty-caption": isEmptyCaption
         }}
         style={{
           "--width": button.width === "" ? "100%" : button.width,


### PR DESCRIPTION
**Changes we propose in this PR**:

- Improve accessibility when the caption is empty in the `gx-button` control. Since we don't have an accessibility name to put on images when the `gx-button` caption is empty, for now, we decided to use the image name as the `alt` property on the `img` tag.

In the future, we want to expose a property to use as an accessibility name.

issue: 93063