### PR TITLE
Housekeeping controls for u8

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -2,10 +2,15 @@
 
 gx-checkbox {
   @include visibility(flex);
-
   @include scss-custom-option-control();
 
   --option-border-radius: 25%;
 
   @include container-margins();
+
+  flex: 1;
+
+  & > [data-readonly] {
+    flex: 1;
+  }
 }

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -11,6 +11,7 @@ gx-checkbox {
   flex: 1;
 
   & > [data-readonly] {
+    display: flex;
     flex: 1;
   }
 }

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -122,6 +122,7 @@ $gx-xsmall-breakpoint-plus-1: 769px;
     align-items: center;
     justify-content: flex-start;
     height: 100%;
+    overflow: hidden;
 
     &[data-part="option-control"]:active {
       padding: 0;

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -121,7 +121,6 @@ $gx-xsmall-breakpoint-plus-1: 769px;
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    height: 100%;
     overflow: hidden;
 
     &[data-part="option-control"]:active {

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -121,6 +121,7 @@ $gx-xsmall-breakpoint-plus-1: 769px;
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    flex: 1;
     overflow: hidden;
 
     &[data-part="option-control"]:active {

--- a/src/components/form-field/form-field.scss
+++ b/src/components/form-field/form-field.scss
@@ -51,9 +51,13 @@ gx-form-field {
 
 [valign="top"] {
   & > gx-form-field {
-    [data-readonly],
+    [data-readonly]:not([direction="vertical"]),
     [data-part="container"] {
       align-items: flex-start;
+    }
+
+    gx-radio-group[direction="vertical"] {
+      justify-content: flex-start;
     }
 
     gx-gauge {
@@ -68,9 +72,13 @@ gx-form-field {
       align-self: center;
     }
 
-    [data-readonly],
+    [data-readonly]:not([direction="vertical"]),
     [data-part="container"] {
       align-items: center;
+    }
+
+    gx-radio-group[direction="vertical"] {
+      justify-content: center;
     }
 
     gx-gauge {
@@ -85,9 +93,13 @@ gx-form-field {
       align-self: flex-end;
     }
 
-    [data-readonly],
+    [data-readonly]:not([direction="vertical"]),
     [data-part="container"] {
       align-items: flex-end;
+    }
+
+    gx-radio-group[direction="vertical"] {
+      justify-content: flex-end;
     }
 
     gx-gauge {

--- a/src/components/form-field/form-field.scss
+++ b/src/components/form-field/form-field.scss
@@ -17,6 +17,9 @@ gx-form-field {
       text-align: start;
     }
 
+    gx-radio-group[direction="vertical"] [data-part="option-control"],
+    gx-radio-group[direction="horizontal"],
+    gx-checkbox [data-part="option-control"],
     gx-gauge {
       justify-content: flex-start;
     }
@@ -30,6 +33,9 @@ gx-form-field {
       text-align: center;
     }
 
+    gx-radio-group[direction="vertical"] [data-part="option-control"],
+    gx-radio-group[direction="horizontal"],
+    gx-checkbox [data-part="option-control"],
     gx-gauge {
       justify-content: center;
     }
@@ -43,6 +49,9 @@ gx-form-field {
       text-align: end;
     }
 
+    gx-radio-group[direction="vertical"] [data-part="option-control"],
+    gx-radio-group[direction="horizontal"],
+    gx-checkbox [data-part="option-control"],
     gx-gauge {
       justify-content: flex-end;
     }

--- a/src/components/form-field/form-field.scss
+++ b/src/components/form-field/form-field.scss
@@ -60,13 +60,23 @@ gx-form-field {
 
 [valign="top"] {
   & > gx-form-field {
-    [data-readonly]:not([direction="vertical"]),
+    /*  gx-radio-group has data-readonly property in its definition, so with
+        :not([direction]) selector we make sure that gx-radio-group will not be
+        affected.
+    */
+    [data-readonly]:not([direction]),
     [data-part="container"] {
       align-items: flex-start;
     }
 
-    gx-radio-group[direction="vertical"] {
-      justify-content: flex-start;
+    gx-radio-group {
+      &[direction="vertical"] {
+        justify-content: flex-start;
+      }
+
+      &[direction="horizontal"] {
+        align-content: flex-start;
+      }
     }
 
     gx-gauge {
@@ -81,13 +91,19 @@ gx-form-field {
       align-self: center;
     }
 
-    [data-readonly]:not([direction="vertical"]),
+    [data-readonly]:not([direction]),
     [data-part="container"] {
       align-items: center;
     }
 
-    gx-radio-group[direction="vertical"] {
-      justify-content: center;
+    gx-radio-group {
+      &[direction="vertical"] {
+        justify-content: center;
+      }
+
+      &[direction="horizontal"] {
+        align-content: center;
+      }
     }
 
     gx-gauge {
@@ -102,13 +118,19 @@ gx-form-field {
       align-self: flex-end;
     }
 
-    [data-readonly]:not([direction="vertical"]),
+    [data-readonly]:not([direction]),
     [data-part="container"] {
       align-items: flex-end;
     }
 
-    gx-radio-group[direction="vertical"] {
-      justify-content: flex-end;
+    gx-radio-group {
+      &[direction="vertical"] {
+        justify-content: flex-end;
+      }
+
+      &[direction="horizontal"] {
+        align-content: flex-end;
+      }
     }
 
     gx-gauge {

--- a/src/components/navbar/navbar.scss
+++ b/src/components/navbar/navbar.scss
@@ -180,10 +180,6 @@
           display: flex;
           justify-content: stretch;
           color: var(--gx-navbar-main-color);
-
-          &:empty {
-            display: none;
-          }
         }
       }
     }

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -11,6 +11,5 @@ gx-radio-group {
 
   &[direction="horizontal"] {
     flex-wrap: wrap;
-    justify-content: space-around;
   }
 }

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -3,6 +3,7 @@
 gx-radio-group {
   @include visibility(flex);
   @include container-margins();
+  flex: 1;
 
   &[direction="vertical"] {
     flex-direction: column;

--- a/src/components/radio-group/radio-group.scss
+++ b/src/components/radio-group/radio-group.scss
@@ -7,10 +7,6 @@ gx-radio-group {
 
   &[direction="vertical"] {
     flex-direction: column;
-
-    & > gx-radio-option {
-      flex: 1;
-    }
   }
 
   &[direction="horizontal"] {

--- a/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
+++ b/src/components/renders/bootstrap/checkbox/checkbox-render.tsx
@@ -73,8 +73,7 @@ export class CheckBoxRender implements Renderer {
       for: attris.id
     };
 
-    return [
-      <gx-bootstrap />,
+    return (
       <div data-readonly="">
         <div
           class="container"
@@ -110,6 +109,6 @@ export class CheckBoxRender implements Renderer {
           </label>
         </div>
       </div>
-    ];
+    );
   }
 }

--- a/src/components/renders/bootstrap/radio-option/radio-option-render.tsx
+++ b/src/components/renders/bootstrap/radio-option/radio-option-render.tsx
@@ -108,8 +108,7 @@ export class RadioOptionRender implements Renderer {
       for: attris.id
     };
 
-    return [
-      <gx-bootstrap />,
+    return (
       <div
         class={this.getInnerControlContainerClass()}
         data-part={!radioOption.disabled ? "option-control" : ""}
@@ -128,6 +127,6 @@ export class RadioOptionRender implements Renderer {
           {radioOption.caption}
         </label>
       </div>
-    ];
+    );
   }
 }

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -9,4 +9,9 @@ gx-table {
   @include visibility(grid);
 
   flex: 1;
+
+  /*  gx-table must hide its content overflow to ensure that the border-radius
+      property is apply
+  */
+  overflow: hidden;
 }


### PR DESCRIPTION
**Changes we propose in this PR**:
- `issue: 94512` Fixed `gx-checkbox` and `gx-radio-group` not streching to full width.

- `issue: 94516` Hide `gx-checkbox` caption overflow.

- `issue: 94520` Added support for vertical and horizontal alignment for `gx-checkbox` and `gx-radio-group`.

- `issue: 94515` Controls inside a `gx-table` were not clipped when the `gx-table` has the `border-radius` property set.