### PR TITLE
Fix dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2004,11 +2004,11 @@
       }
     },
     "dom7": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-2.1.5.tgz",
-      "integrity": "sha512-xnhwVgyOh3eD++/XGtH+5qBwYTgCm0aW91GFgPJ3XG+jlsRLyJivnbP0QmUBFhI+Oaz9FV0s7cxgXHezwOEBYA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-3.0.0.tgz",
+      "integrity": "sha512-oNlcUdHsC4zb7Msx7JN3K0Nro1dzJ48knvBOnDPKJ2GV9wl1i5vydJZUSyOfrkKFDZEud/jBsTk92S/VGSAe/g==",
       "requires": {
-        "ssr-window": "^2.0.0"
+        "ssr-window": "^3.0.0-alpha.1"
       }
     },
     "domexception": {
@@ -2874,9 +2874,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -3023,9 +3023,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -3232,9 +3232,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -4216,9 +4216,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -4258,14 +4258,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -4683,9 +4683,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.debounce": {
@@ -5454,9 +5454,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-type": {
@@ -6623,9 +6623,9 @@
       }
     },
     "ssr-window": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-2.0.0.tgz",
-      "integrity": "sha512-NXzN+/HPObKAx191H3zKlYomE5WrVIkoCB5IaSdvKokxTpjBdWfr0RaP+1Z5KOfDT0ZVz+2tdtiBkhsEQ9p+0A=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-3.0.0.tgz",
+      "integrity": "sha512-q+8UfWDg9Itrg0yWK7oe5p/XRCJpJF9OBtXfOPgSJl+u3Xd5KI328RUEvUqSMVM9CiQUEf1QdBzJMkYGErj9QA=="
     },
     "stack-utils": {
       "version": "1.0.2",
@@ -6705,9 +6705,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "strip-ansi": {
@@ -6818,12 +6818,12 @@
       }
     },
     "swiper": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-5.4.5.tgz",
-      "integrity": "sha512-7QjA0XpdOmiMoClfaZ2lYN6ICHcMm72LXiY+NF4fQLFidigameaofvpjEEiTQuw3xm5eksG5hzkaRsjQX57vtA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-6.5.2.tgz",
+      "integrity": "sha512-a5PiGG9IxdRrFFHU4IdG2m02R1i+pY0vC2p/aiDKiwW6JIpOVFuEJmUumvIGPmjELTxb8TGTSsI4cNWOKgOBVQ==",
       "requires": {
-        "dom7": "^2.1.5",
-        "ssr-window": "^2.0.0"
+        "dom7": "^3.0.0",
+        "ssr-window": "^3.0.0"
       }
     },
     "symbol-observable": {
@@ -6915,9 +6915,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -7323,9 +7323,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "leaflet": "^1.3.4",
     "lottie-web": "^5.2.1",
     "popper.js": "^1.14.7",
-    "swiper": "^5.4.5"
+    "swiper": "^6.5.2"
   },
   "devDependencies": {
     "@stencil/core": "^1.16.4",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -50,6 +50,10 @@ export namespace Components {
      */
     disabled: false;
     /**
+     * This attribute lets you specify the height.
+     */
+    height: string;
+    /**
      * True to highlight control when an action is fired.
      */
     highlightable: false;
@@ -65,6 +69,10 @@ export namespace Components {
      * This attribute lets you specify the size of the button.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `large`  | Large sized button.                                     | | `normal` | Standard sized button.                                  | | `small`  | Small sized button.                                     |
      */
     size: "large" | "normal" | "small";
+    /**
+     * This attribute lets you specify the width.
+     */
+    width: string;
   }
   interface GxCanvas {
     /**
@@ -137,6 +145,10 @@ export namespace Components {
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
     invisibleMode: "collapse" | "keep-space";
+    /**
+     * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.
+     */
+    readonly: false;
     /**
      * The value when the checkbox is 'off'
      */
@@ -224,6 +236,10 @@ export namespace Components {
       | "caption1"
       | "caption2";
     /**
+     * It specifies the format that will have the edit control.  If `format` = `HTML`, the edit control works as an HTML div and the innerHTML will be the same as the `inner` property specifies. Also, it does not allow any input/editable UI since it works as an HTML div.  If `format` = `Text`, the edit control works as a normal input control and it is affected by most of the defined properties.
+     */
+    format: "Text" | "HTML";
+    /**
      * Returns the id of the inner `input` element (if set).
      */
     getNativeInputId: () => Promise<string>;
@@ -231,6 +247,10 @@ export namespace Components {
      * True to highlight control when an action is fired.
      */
     highlightable: false;
+    /**
+     * Used as the innerHTML when `format` = `HTML`.
+     */
+    inner: string;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -252,13 +272,9 @@ export namespace Components {
      */
     readonly: boolean;
     /**
-     * If true, a trigger button is shown next to the edit field. The button can be customized using `trigger-text` and `trigger-class` attributes, or adding a child element with `slot="trigger-content"` attribute to specify the content inside the trigger button.
+     * If true, a trigger button is shown next to the edit field. The button can be customized adding a child element with `slot="trigger-content"` attribute to specify the content inside the trigger button.
      */
     showTrigger: boolean;
-    /**
-     * The text of the trigger button. If a text is specified and an image is specified (through an element with `slot="trigger-content"`), the content is ignored and the text is used instead.
-     */
-    triggerText: string;
     /**
      * The type of control to render. A subset of the types supported by the `input` element is supported:  * `"date"` * `"datetime-local"` * `"email"` * `"file"` * `"number"` * `"password"` * `"search"` * `"tel"` * `"text"` * `"url"`
      */
@@ -272,6 +288,7 @@ export namespace Components {
       | "search"
       | "tel"
       | "text"
+      | "time"
       | "url";
     /**
      * The initial value of the control.
@@ -649,7 +666,7 @@ export namespace Components {
     /**
      * This attribute lets you specify the alternative text.
      */
-    alt: "";
+    alt: string;
     /**
      * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
      */
@@ -685,7 +702,77 @@ export namespace Components {
     /**
      * This attribute lets you specify the SRC.
      */
-    src: "";
+    src: string;
+    /**
+     * This attribute lets you specify the width.
+     */
+    width: string;
+  }
+  interface GxImagePicker {
+    /**
+     * This attribute lets you specify the alternative text.
+     */
+    alt: string;
+    /**
+     * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
+     */
+    autoGrow: true;
+    /**
+     * This attribute lets you specify the description of the cancel action button in the modal.
+     */
+    cancelButtonText: "CANCEL";
+    /**
+     * This attribute lets you specify the description of the change image button in the modal.
+     */
+    changeButtonText: "Change image...";
+    /**
+     * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+     */
+    disabled: false;
+    /**
+     * This attribute lets you specify the height.
+     */
+    height: string;
+    /**
+     * True to highlight control when an action is fired.
+     */
+    highlightable: false;
+    /**
+     * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
+     */
+    invisibleMode: "collapse" | "keep-space";
+    /**
+     * True to lazy load the image, when it enters the viewport.
+     */
+    lazyLoad: true;
+    /**
+     * This attribute lets you specify the low resolution image SRC.
+     */
+    lowResolutionSrc: "";
+    /**
+     * This attribute lets you specify the modal title.
+     */
+    modalTitle: any;
+    /**
+     * This attribute lets you specify if the image is readonly. If readonly, it will not allow to use the edit button. In fact, the edit button will not be shown.
+     */
+    readonly: false;
+    /**
+     * This attribute lets you specify the description of the remove image button in the modal.
+     */
+    removeButtonText: "Remove image";
+    /**
+     * This attribute allows specifing how the image is sized according to its container. `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property. The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
+     */
+    scaleType: "contain" | "cover" | "fill" | "none" | "tile";
+    /**
+     * This attribute lets you specify the SRC.
+     */
+    src: string;
+    /**
+     * This attribute lets you specify the current state of the gx-image-picker.  | Value               | Details                                                                                      | | ------------------- | -------------------------------------------------------------------------------------------- | | `readyToUse`        | Allows you to choose, change or remove an image.                                             | | `fileReadyToUpload` | It is set only after an image has been selected or changed, not removed.                     | | `uploadingFile`     | It is set by the parent control to specifies when the image is being uploaded to the server. |  `fileReadyToUpload` and `uploadingFile` will not allow you to change or remove the current image.
+     */
+    state: "readyToUse" | "fileReadyToUpload" | "uploadingFile";
     /**
      * This attribute lets you specify the width.
      */
@@ -732,6 +819,10 @@ export namespace Components {
      * Sets the description text.
      */
     description: string;
+    /**
+     * Sets if the loading will be separated from the main content of the page. If `dialog = true` the `gx-loading` will be displayed separately from the main content the web page in a dialog box. If `dialog = false` the `gx-loading` will be displayed inside its container and will not be separated from the web page.
+     */
+    dialog: false;
     /**
      * Sets if the loading dialog is presented.
      */
@@ -904,6 +995,10 @@ export namespace Components {
      */
     caption: string;
     /**
+     * This attribute lets you specify the position of the navbar in the viewport. If `position = "top"` the navbar will be placed normally at the top of the viewport. If `position = "bottom"` the navbar will be placed normally at the bottom of the viewport. This `position` of navbar is used to show navigation links.
+     */
+    position: "top" | "bottom";
+    /**
      * True to show the back button
      */
     showBackButton: false;
@@ -1055,7 +1150,7 @@ export namespace Components {
       | "StepTimeline"
       | "Sparkline";
     /**
-     * Title of the QueryViewer
+     * Version of data
      */
     dataVersionId: number;
     /**
@@ -1550,6 +1645,14 @@ export namespace Components {
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
     invisibleMode: "collapse" | "keep-space";
+    /**
+     * Defines how the tabs will be distributed in the Strip.  | Value        | Details                                                                            | | ------------ | ---------------------------------------------------------------------------------- | | `scoll`      | Allows scrolling the tab control when the number of tabs exceeds the screen width. | | `fixed-size` | Tabs are fixed size. Used with any amount of tabs.                                 |
+     */
+    tabsDistribution: "scroll" | "fixed-size";
+    /**
+     * Specifies the position to show the tabs.
+     */
+    tabsPosition: "top" | "bottom";
   }
   interface GxTabCaption {
     /**
@@ -1559,7 +1662,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify the relative location of the image to the text.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `above`  | The image is located above the text.                    | | `before` | The image is located before the text, in the same line. | | `after`  | The image is located after the text, in the same line.  | | `below`  | The image is located below the text.                    | | `behind` | The image is located behind the text.                   |
      */
@@ -1632,6 +1735,10 @@ export namespace Components {
      */
     disabled: false;
     /**
+     * It specifies the format that will have the textblock control.  If `format` = `HTML`, the textblock control works as an HTML div and the innerHTML will be the same as the `inner` property specifies.  If `format` = `Text`, the control works as a normal textblock control and it is affected by most of the defined properties.
+     */
+    format: "Text" | "HTML";
+    /**
      * True to highlight control when an action is fired.
      */
     highlightable: false;
@@ -1639,6 +1746,10 @@ export namespace Components {
      * This attribute lets you specify an URL. If a URL is specified, the textblock acts as an anchor.
      */
     href: "";
+    /**
+     * Used as the innerHTML when `format` = `HTML`.
+     */
+    inner: string;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1824,6 +1935,13 @@ declare global {
   var HTMLGxImageElement: {
     prototype: HTMLGxImageElement;
     new (): HTMLGxImageElement;
+  };
+  interface HTMLGxImagePickerElement
+    extends Components.GxImagePicker,
+      HTMLStencilElement {}
+  var HTMLGxImagePickerElement: {
+    prototype: HTMLGxImagePickerElement;
+    new (): HTMLGxImagePickerElement;
   };
   interface HTMLGxInteractiveImageElement
     extends Components.GxInteractiveImage,
@@ -2058,6 +2176,7 @@ declare global {
     "gx-group": HTMLGxGroupElement;
     "gx-icon": HTMLGxIconElement;
     "gx-image": HTMLGxImageElement;
+    "gx-image-picker": HTMLGxImagePickerElement;
     "gx-interactive-image": HTMLGxInteractiveImageElement;
     "gx-layout": HTMLGxLayoutElement;
     "gx-loading": HTMLGxLoadingElement;
@@ -2141,6 +2260,10 @@ declare namespace LocalJSX {
      */
     disabled?: false;
     /**
+     * This attribute lets you specify the height.
+     */
+    height?: string;
+    /**
      * True to highlight control when an action is fired.
      */
     highlightable?: false;
@@ -2156,6 +2279,10 @@ declare namespace LocalJSX {
      * This attribute lets you specify the size of the button.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `large`  | Large sized button.                                     | | `normal` | Standard sized button.                                  | | `small`  | Small sized button.                                     |
      */
     size?: "large" | "normal" | "small";
+    /**
+     * This attribute lets you specify the width.
+     */
+    width?: string;
   }
   interface GxCanvas {
     /**
@@ -2179,7 +2306,7 @@ declare namespace LocalJSX {
      */
     onSwipeDown?: (event: CustomEvent<any>) => void;
     /**
-     * Emitted when the element is swiped left direction..
+     * Emitted when the element is swiped left direction.
      */
     onSwipeLeft?: (event: CustomEvent<any>) => void;
     /**
@@ -2252,6 +2379,10 @@ declare namespace LocalJSX {
      * The `input` event is emitted when a change to the element's value is committed by the user.
      */
     onInput?: (event: CustomEvent<any>) => void;
+    /**
+     * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.
+     */
+    readonly?: false;
     /**
      * The value when the checkbox is 'off'
      */
@@ -2339,9 +2470,17 @@ declare namespace LocalJSX {
       | "caption1"
       | "caption2";
     /**
+     * It specifies the format that will have the edit control.  If `format` = `HTML`, the edit control works as an HTML div and the innerHTML will be the same as the `inner` property specifies. Also, it does not allow any input/editable UI since it works as an HTML div.  If `format` = `Text`, the edit control works as a normal input control and it is affected by most of the defined properties.
+     */
+    format?: "Text" | "HTML";
+    /**
      * True to highlight control when an action is fired.
      */
     highlightable?: false;
+    /**
+     * Used as the innerHTML when `format` = `HTML`.
+     */
+    inner?: string;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -2375,13 +2514,9 @@ declare namespace LocalJSX {
      */
     readonly?: boolean;
     /**
-     * If true, a trigger button is shown next to the edit field. The button can be customized using `trigger-text` and `trigger-class` attributes, or adding a child element with `slot="trigger-content"` attribute to specify the content inside the trigger button.
+     * If true, a trigger button is shown next to the edit field. The button can be customized adding a child element with `slot="trigger-content"` attribute to specify the content inside the trigger button.
      */
     showTrigger?: boolean;
-    /**
-     * The text of the trigger button. If a text is specified and an image is specified (through an element with `slot="trigger-content"`), the content is ignored and the text is used instead.
-     */
-    triggerText?: string;
     /**
      * The type of control to render. A subset of the types supported by the `input` element is supported:  * `"date"` * `"datetime-local"` * `"email"` * `"file"` * `"number"` * `"password"` * `"search"` * `"tel"` * `"text"` * `"url"`
      */
@@ -2395,6 +2530,7 @@ declare namespace LocalJSX {
       | "search"
       | "tel"
       | "text"
+      | "time"
       | "url";
     /**
      * The initial value of the control.
@@ -2593,7 +2729,7 @@ declare namespace LocalJSX {
     /**
      * Emitted when the user taps/clicks on the slide's container.
      */
-    onGxGridClick?: (event: CustomEvent<void>) => void;
+    onGxGridClick?: (event: CustomEvent<any>) => void;
     /**
      * Emitted after the active slide has changed.
      */
@@ -2605,27 +2741,27 @@ declare namespace LocalJSX {
     /**
      * Emitted when the user double taps on the slide's container.
      */
-    onGxGridDoubleClick?: (event: CustomEvent<void>) => void;
+    onGxGridDoubleClick?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the slider is actively being moved.
      */
-    onGxGridDrag?: (event: CustomEvent<void>) => void;
+    onGxGridDrag?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the next slide has ended.
      */
-    onGxGridNextEnd?: (event: CustomEvent<void>) => void;
+    onGxGridNextEnd?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the next slide has started.
      */
-    onGxGridNextStart?: (event: CustomEvent<void>) => void;
+    onGxGridNextStart?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the previous slide has ended.
      */
-    onGxGridPrevEnd?: (event: CustomEvent<void>) => void;
+    onGxGridPrevEnd?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the previous slide has started.
      */
-    onGxGridPrevStart?: (event: CustomEvent<void>) => void;
+    onGxGridPrevStart?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the slider is at the last slide.
      */
@@ -2633,27 +2769,27 @@ declare namespace LocalJSX {
     /**
      * Emitted when the slider is at its initial position.
      */
-    onGxGridReachStart?: (event: CustomEvent<void>) => void;
+    onGxGridReachStart?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the user releases the touch.
      */
-    onGxGridTouchEnd?: (event: CustomEvent<void>) => void;
+    onGxGridTouchEnd?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the user first touches the slider.
      */
-    onGxGridTouchStart?: (event: CustomEvent<void>) => void;
+    onGxGridTouchStart?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the slide transition has ended.
      */
-    onGxGridTransitionEnd?: (event: CustomEvent<void>) => void;
+    onGxGridTransitionEnd?: (event: CustomEvent<any>) => void;
     /**
      * Emitted when the slide transition has started.
      */
-    onGxGridTransitionStart?: (event: CustomEvent<void>) => void;
+    onGxGridTransitionStart?: (event: CustomEvent<any>) => void;
     /**
      * Emitted before the active slide has changed.
      */
-    onGxGridWillChange?: (event: CustomEvent<void>) => void;
+    onGxGridWillChange?: (event: CustomEvent<any>) => void;
     /**
      * This Handler will be called every time grid threshold is reached. Needed for infinite scrolling grids.
      */
@@ -2790,7 +2926,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify the alternative text.
      */
-    alt?: "";
+    alt?: string;
     /**
      * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
      */
@@ -2826,7 +2962,85 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify the SRC.
      */
-    src?: "";
+    src?: string;
+    /**
+     * This attribute lets you specify the width.
+     */
+    width?: string;
+  }
+  interface GxImagePicker {
+    /**
+     * This attribute lets you specify the alternative text.
+     */
+    alt?: string;
+    /**
+     * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
+     */
+    autoGrow?: true;
+    /**
+     * This attribute lets you specify the description of the cancel action button in the modal.
+     */
+    cancelButtonText?: "CANCEL";
+    /**
+     * This attribute lets you specify the description of the change image button in the modal.
+     */
+    changeButtonText?: "Change image...";
+    /**
+     * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
+     */
+    disabled?: false;
+    /**
+     * This attribute lets you specify the height.
+     */
+    height?: string;
+    /**
+     * True to highlight control when an action is fired.
+     */
+    highlightable?: false;
+    /**
+     * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
+     */
+    invisibleMode?: "collapse" | "keep-space";
+    /**
+     * True to lazy load the image, when it enters the viewport.
+     */
+    lazyLoad?: true;
+    /**
+     * This attribute lets you specify the low resolution image SRC.
+     */
+    lowResolutionSrc?: "";
+    /**
+     * This attribute lets you specify the modal title.
+     */
+    modalTitle?: any;
+    /**
+     * Fired when the image is clicked
+     */
+    onClick?: (event: CustomEvent<any>) => void;
+    /**
+     * Fired when the image is changed
+     */
+    onOnImageChanged?: (event: CustomEvent<File>) => void;
+    /**
+     * This attribute lets you specify if the image is readonly. If readonly, it will not allow to use the edit button. In fact, the edit button will not be shown.
+     */
+    readonly?: false;
+    /**
+     * This attribute lets you specify the description of the remove image button in the modal.
+     */
+    removeButtonText?: "Remove image";
+    /**
+     * This attribute allows specifing how the image is sized according to its container. `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property. The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
+     */
+    scaleType?: "contain" | "cover" | "fill" | "none" | "tile";
+    /**
+     * This attribute lets you specify the SRC.
+     */
+    src?: string;
+    /**
+     * This attribute lets you specify the current state of the gx-image-picker.  | Value               | Details                                                                                      | | ------------------- | -------------------------------------------------------------------------------------------- | | `readyToUse`        | Allows you to choose, change or remove an image.                                             | | `fileReadyToUpload` | It is set only after an image has been selected or changed, not removed.                     | | `uploadingFile`     | It is set by the parent control to specifies when the image is being uploaded to the server. |  `fileReadyToUpload` and `uploadingFile` will not allow you to change or remove the current image.
+     */
+    state?: "readyToUse" | "fileReadyToUpload" | "uploadingFile";
     /**
      * This attribute lets you specify the width.
      */
@@ -2885,6 +3099,10 @@ declare namespace LocalJSX {
      * Sets the description text.
      */
     description?: string;
+    /**
+     * Sets if the loading will be separated from the main content of the page. If `dialog = true` the `gx-loading` will be displayed separately from the main content the web page in a dialog box. If `dialog = false` the `gx-loading` will be displayed inside its container and will not be separated from the web page.
+     */
+    dialog?: false;
     /**
      * Sets if the loading dialog is presented.
      */
@@ -3104,6 +3322,10 @@ declare namespace LocalJSX {
      */
     onToggleButtonClick?: (event: CustomEvent<any>) => void;
     /**
+     * This attribute lets you specify the position of the navbar in the viewport. If `position = "top"` the navbar will be placed normally at the top of the viewport. If `position = "bottom"` the navbar will be placed normally at the bottom of the viewport. This `position` of navbar is used to show navigation links.
+     */
+    position?: "top" | "bottom";
+    /**
      * True to show the back button
      */
     showBackButton?: false;
@@ -3259,7 +3481,7 @@ declare namespace LocalJSX {
       | "StepTimeline"
       | "Sparkline";
     /**
-     * Title of the QueryViewer
+     * Version of data
      */
     dataVersionId?: number;
     /**
@@ -3804,6 +4026,14 @@ declare namespace LocalJSX {
      * Fired when the active tab is changed
      */
     onTabChange?: (event: CustomEvent<any>) => void;
+    /**
+     * Defines how the tabs will be distributed in the Strip.  | Value        | Details                                                                            | | ------------ | ---------------------------------------------------------------------------------- | | `scoll`      | Allows scrolling the tab control when the number of tabs exceeds the screen width. | | `fixed-size` | Tabs are fixed size. Used with any amount of tabs.                                 |
+     */
+    tabsDistribution?: "scroll" | "fixed-size";
+    /**
+     * Specifies the position to show the tabs.
+     */
+    tabsPosition?: "top" | "bottom";
   }
   interface GxTabCaption {
     /**
@@ -3813,7 +4043,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify the relative location of the image to the text.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `above`  | The image is located above the text.                    | | `before` | The image is located before the text, in the same line. | | `after`  | The image is located after the text, in the same line.  | | `below`  | The image is located below the text.                    | | `behind` | The image is located behind the text.                   |
      */
@@ -3910,6 +4140,10 @@ declare namespace LocalJSX {
      */
     disabled?: false;
     /**
+     * It specifies the format that will have the textblock control.  If `format` = `HTML`, the textblock control works as an HTML div and the innerHTML will be the same as the `inner` property specifies.  If `format` = `Text`, the control works as a normal textblock control and it is affected by most of the defined properties.
+     */
+    format?: "Text" | "HTML";
+    /**
      * True to highlight control when an action is fired.
      */
     highlightable?: false;
@@ -3917,6 +4151,10 @@ declare namespace LocalJSX {
      * This attribute lets you specify an URL. If a URL is specified, the textblock acts as an anchor.
      */
     href?: "";
+    /**
+     * Used as the innerHTML when `format` = `HTML`.
+     */
+    inner?: string;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -3970,6 +4208,7 @@ declare namespace LocalJSX {
     "gx-group": GxGroup;
     "gx-icon": GxIcon;
     "gx-image": GxImage;
+    "gx-image-picker": GxImagePicker;
     "gx-interactive-image": GxInteractiveImage;
     "gx-layout": GxLayout;
     "gx-loading": GxLoading;
@@ -4050,6 +4289,8 @@ declare module "@stencil/core" {
       "gx-group": LocalJSX.GxGroup & JSXBase.HTMLAttributes<HTMLGxGroupElement>;
       "gx-icon": LocalJSX.GxIcon & JSXBase.HTMLAttributes<HTMLGxIconElement>;
       "gx-image": LocalJSX.GxImage & JSXBase.HTMLAttributes<HTMLGxImageElement>;
+      "gx-image-picker": LocalJSX.GxImagePicker &
+        JSXBase.HTMLAttributes<HTMLGxImagePickerElement>;
       "gx-interactive-image": LocalJSX.GxInteractiveImage &
         JSXBase.HTMLAttributes<HTMLGxInteractiveImageElement>;
       "gx-layout": LocalJSX.GxLayout &

--- a/src/components/grid-horizontal/grid-horizontal.scss
+++ b/src/components/grid-horizontal/grid-horizontal.scss
@@ -1,5 +1,5 @@
 @import "../grid-base/grid-base.scss";
-@import "../../../node_modules/swiper/css/swiper.min.css";
+@import "../../../node_modules/swiper/swiper.min.css";
 
 gx-grid-horizontal {
   & > [slot="grid-empty-loading-placeholder"] {

--- a/src/components/grid-horizontal/grid-horizontal.tsx
+++ b/src/components/grid-horizontal/grid-horizontal.tsx
@@ -136,17 +136,17 @@ export class GridHorizontal
   /**
    * Emitted when the user taps/clicks on the slide's container.
    */
-  @Event() gxGridClick!: EventEmitter<void>;
+  @Event() gxGridClick!: EventEmitter;
 
   /**
    * Emitted when the user double taps on the slide's container.
    */
-  @Event() gxGridDoubleClick!: EventEmitter<void>;
+  @Event() gxGridDoubleClick!: EventEmitter;
 
   /**
    * Emitted before the active slide has changed.
    */
-  @Event() gxGridWillChange!: EventEmitter<void>;
+  @Event() gxGridWillChange!: EventEmitter;
 
   /**
    * Emitted after the active slide has changed.
@@ -156,42 +156,42 @@ export class GridHorizontal
   /**
    * Emitted when the next slide has started.
    */
-  @Event() gxGridNextStart!: EventEmitter<void>;
+  @Event() gxGridNextStart!: EventEmitter;
 
   /**
    * Emitted when the previous slide has started.
    */
-  @Event() gxGridPrevStart!: EventEmitter<void>;
+  @Event() gxGridPrevStart!: EventEmitter;
 
   /**
    * Emitted when the next slide has ended.
    */
-  @Event() gxGridNextEnd!: EventEmitter<void>;
+  @Event() gxGridNextEnd!: EventEmitter;
 
   /**
    * Emitted when the previous slide has ended.
    */
-  @Event() gxGridPrevEnd!: EventEmitter<void>;
+  @Event() gxGridPrevEnd!: EventEmitter;
 
   /**
    * Emitted when the slide transition has started.
    */
-  @Event() gxGridTransitionStart!: EventEmitter<void>;
+  @Event() gxGridTransitionStart!: EventEmitter;
 
   /**
    * Emitted when the slide transition has ended.
    */
-  @Event() gxGridTransitionEnd!: EventEmitter<void>;
+  @Event() gxGridTransitionEnd!: EventEmitter;
 
   /**
    * Emitted when the slider is actively being moved.
    */
-  @Event() gxGridDrag!: EventEmitter<void>;
+  @Event() gxGridDrag!: EventEmitter;
 
   /**
    * Emitted when the slider is at its initial position.
    */
-  @Event() gxGridReachStart!: EventEmitter<void>;
+  @Event() gxGridReachStart!: EventEmitter;
 
   /**
    * Emitted when the slider is at the last slide.
@@ -201,12 +201,12 @@ export class GridHorizontal
   /**
    * Emitted when the user first touches the slider.
    */
-  @Event() gxGridTouchStart!: EventEmitter<void>;
+  @Event() gxGridTouchStart!: EventEmitter;
 
   /**
    * Emitted when the user releases the touch.
    */
-  @Event() gxGridTouchEnd!: EventEmitter<void>;
+  @Event() gxGridTouchEnd!: EventEmitter;
 
   private getSwiperCurrentPage() {
     return this.currentPage - 1;
@@ -471,14 +471,16 @@ export class GridHorizontal
       threshold: 0,
       touchMoveStopPropagation: true,
       touchReleaseOnEdges: false,
-      iOSEdgeSwipeDetection: false,
-      iOSEdgeSwipeThreshold: 20,
+      edgeSwipeDetection: false,
+      edgeSwipeThreshold: 20,
       mousewheel: false,
       resistance: true,
       resistanceRatio: 0.85,
       roundLengths: true,
+
+      // This aditionally triggers previous: watchSlidesVisibility: false
+      // https://swiperjs.com/swiper-api#param-watchSlidesProgress
       watchSlidesProgress: false,
-      watchSlidesVisibility: false,
       watchOverflow: this.pager,
       preventClicks: true,
       preventClicksPropagation: true,


### PR DESCRIPTION
For the critical severity vulnerabilities:
 - Updated swiper to 6.5.2.
   - Removed `watchSlidesProgress` property due this property is now included in the implementation of `watchSlidesProgress` property. https://swiperjs.com/swiper-api#param-watchSlidesProgress

   - Renamed `iOSEdgeSwipeDetection` -> `edgeSwipeDetection`

   - Renamed `iOSEdgeSwipeThreshold` -> `edgeSwipeThreshold`

For the high severity vulnerabilities:
 - They were fix with `npm audit fix` command

Also `npm audit fix` command fixed a great amount of "moderate" severity vulnerabilities.


Previously:
> found 114 vulnerabilities (84 moderate, 29 high, 1 critical)

Now:

> found 26 moderate severity vulnerabilities

issue: 94603