### PR TITLE
Added support for width and height properties in `gx-modal`.

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -36,6 +36,11 @@ export class Modal implements GxComponent {
   @Prop() readonly closeButtonLabel: string;
 
   /**
+   * This attribute lets you specify the height of the control.
+   */
+  @Prop() readonly height: string = null;
+
+  /**
    * This attribute lets you specify if the modal dialog is opened or closed.
    */
   @Prop({ mutable: true }) opened = false;
@@ -44,6 +49,11 @@ export class Modal implements GxComponent {
    * This attribute lets you specify if a header is renderd on top of the modal dialog.
    */
   @Prop() showHeader = true;
+
+  /**
+   * This attribute lets you specify the width of the control.
+   */
+  @Prop() readonly width: string = null;
 
   /**
    * Fired when the modal dialog is closed

--- a/src/components/modal/readme.md
+++ b/src/components/modal/readme.md
@@ -38,8 +38,10 @@ predefined slots:
 | ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------ | --------- | ----------- |
 | `autoClose`        | `auto-close`         | This attribute lets you specify if the modal dialog is automatically closed when an action is clicked. | `boolean` | `undefined` |
 | `closeButtonLabel` | `close-button-label` | This attribute lets you specify the label for the close button. Important for accessibility.           | `string`  | `undefined` |
+| `height`           | `height`             | This attribute lets you specify the height of the control.                                             | `string`  | `null`      |
 | `opened`           | `opened`             | This attribute lets you specify if the modal dialog is opened or closed.                               | `boolean` | `false`     |
 | `showHeader`       | `show-header`        | This attribute lets you specify if a header is renderd on top of the modal dialog.                     | `boolean` | `true`      |
+| `width`            | `width`              | This attribute lets you specify the width of the control.                                              | `string`  | `null`      |
 
 ## Events
 

--- a/src/components/renders/bootstrap/modal/modal-render.tsx
+++ b/src/components/renders/bootstrap/modal/modal-render.tsx
@@ -89,7 +89,13 @@ export class ModalRender implements Renderer {
         aria-hidden="true"
       >
         <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
+          <div
+            class="modal-content"
+            style={{
+              width: this.component.width,
+              height: this.component.height
+            }}
+          >
             {modal.showHeader && (
               <div class="modal-header">
                 <h5 class="modal-title" id={this.headerId}>


### PR DESCRIPTION
Those properties refer to the TargetWidth and TargetHeight properties of the CallOptions.

issue: 94659