### PR TITLE
The gx-modal is no longer at the top of z-index

### DIFF
--- a/src/components/common/_layout-styling-config.scss
+++ b/src/components/common/_layout-styling-config.scss
@@ -15,12 +15,12 @@ $z-index-8: $base-z-index + 8;
 $z-index-9: $base-z-index + 9;
 $z-index-10: $base-z-index + 10;
 
-$z-index-gx-modal: $z-index-9;
-$z-index-gx-loading-box: $z-index-8;
-$z-index-gx-loading: $z-index-7;
-$z-index-gx-navbar-item: $z-index-6;
-$z-index-gx-navbar: $z-index-5;
-$z-index-gx-message: $z-index-4;
+$z-index-gx-loading-box: $z-index-9;
+$z-index-gx-loading: $z-index-8;
+$z-index-gx-navbar-item: $z-index-7;
+$z-index-gx-navbar: $z-index-6;
+$z-index-gx-message: $z-index-5;
+$z-index-gx-modal: $z-index-4;
 $z-index-gx-layout-vertical: $z-index-3;
 $z-index-gx-layout-mask: $z-index-2;
 $z-index-gx-layout: $z-index-1;


### PR DESCRIPTION
**Changes we propose in this PR**:
- The `gx-modal` control will be displayed below the message and above the layout.

issue:96749