### PR TITLE
Fix for Invisible Mode not working on gx-component-host

### DIFF
--- a/src/components/canvas-cell/canvas-cell.tsx
+++ b/src/components/canvas-cell/canvas-cell.tsx
@@ -51,7 +51,10 @@ export class CanvasCell implements GxComponent {
   private observer: MutationObserver;
 
   private setupObserver(childElement: any) {
-    if (childElement && childElement.invisibleMode === "collapse") {
+    if (
+      childElement &&
+      childElement.getAttribute("invisible-mode") === "collapse"
+    ) {
       this.observer = new MutationObserver(() => {
         this.setVisibilityBasedOnChildElement(childElement);
       });

--- a/src/components/table-cell/table-cell.tsx
+++ b/src/components/table-cell/table-cell.tsx
@@ -48,7 +48,7 @@ export class TableCell implements GxComponent {
   componentDidLoad() {
     const childElement: any = this.element.firstElementChild;
 
-    if (childElement?.invisibleMode !== "collapse") {
+    if (childElement?.getAttribute("invisible-mode") !== "collapse") {
       return;
     }
 


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Fix for Invisible Mode not working on `gx-component-host`.
   Since not all components will have the invisibleMode attribute as a property of their model, it's best to check the invisibleMode property reading it as a DOM attribute.

[issue:100381](https://issues.genexus.com/viewissue.aspx?IssueId=100381&TabCode=)