### PR TITLE
Fixes and improvements for the gx-video control

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2118,10 +2118,6 @@ export namespace Components {
      */
     disabled: false;
     /**
-     * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
-     */
-    invisibleMode: "collapse" | "keep-space";
-    /**
      * This attribute is for specifies the src of the video.
      */
     src: string;
@@ -2291,10 +2287,6 @@ export interface GxTabCaptionCustomEvent<T> extends CustomEvent<T> {
 export interface GxTableCustomEvent<T> extends CustomEvent<T> {
   detail: T;
   target: HTMLGxTableElement;
-}
-export interface GxVideoCustomEvent<T> extends CustomEvent<T> {
-  detail: T;
-  target: HTMLGxVideoElement;
 }
 declare global {
   interface HTMLGxActionSheetElement
@@ -5137,14 +5129,6 @@ declare namespace LocalJSX {
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
     disabled?: false;
-    /**
-     * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
-     */
-    invisibleMode?: "collapse" | "keep-space";
-    /**
-     * Emitted when the element is clicked.
-     */
-    onGxClick?: (event: GxVideoCustomEvent<any>) => void;
     /**
      * This attribute is for specifies the src of the video.
      */

--- a/src/components/video/readme.md
+++ b/src/components/video/readme.md
@@ -4,36 +4,27 @@ A component to load a video.
 
 ## Video Support
 
-At the moment it only supports Youtube videos. Future updates will support videos URLs from other video publishers and single video files.
+It supports Youtube videos, URLs from other video publishers and single video files.
+It does not support multiple video sources.
 
 ## Usage Sample
 
 ```HTML
-<gx-video src="https://www.youtube.com/watch?v=k2jT6TlxEOM" style="--gx-video-height: 50vh;"></gx-video>
+<gx-video src="https://www.youtube.com/watch?v=k2jT6TlxEOM"></gx-video>
+```
+
+```HTML
+<gx-video src="https://www.w3schools.com/tags/movie.mp4"></gx-video>
 ```
 
 <!-- Auto Generated Below -->
 
 ## Properties
 
-| Property        | Attribute        | Description                                                                                                                                                                                                                                                                                                                                                                                  | Type                         | Default      |
-| --------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------ |
-| `disabled`      | `disabled`       | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).                                                                                                                                                                                                                                     | `boolean`                    | `false`      |
-| `invisibleMode` | `invisible-mode` | This attribute lets you specify how this element will behave when hidden. \| Value \| Details \| \| ------------ \| --------------------------------------------------------------------------- \| \| `keep-space` \| The element remains in the document flow, and it does occupy space. \| \| `collapse` \| The element is removed form the document flow, and it doesn't occupy space. \| | `"collapse" \| "keep-space"` | `"collapse"` |
-| `src`           | `src`            | This attribute is for specifies the src of the video.                                                                                                                                                                                                                                                                                                                                        | `string`                     | `undefined`  |
-
-## Events
-
-| Event     | Description                          | Type               |
-| --------- | ------------------------------------ | ------------------ |
-| `gxClick` | Emitted when the element is clicked. | `CustomEvent<any>` |
-
-## CSS Custom Properties
-
-| Name                | Description                                                                                     |
-| ------------------- | ----------------------------------------------------------------------------------------------- |
-| `--gx-video-height` | Set the height of the control from the video container or the control itself. (100% by default) |
-| `--gx-video-width`  | Set the width of the control from the video container or the control itself. (100% by default)  |
+| Property   | Attribute  | Description                                                                                                                                              | Type      | Default     |
+| ---------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `disabled` | `disabled` | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event). | `boolean` | `false`     |
+| `src`      | `src`      | This attribute is for specifies the src of the video.                                                                                                    | `string`  | `undefined` |
 
 ---
 

--- a/src/components/video/video.scss
+++ b/src/components/video/video.scss
@@ -1,31 +1,21 @@
 @import "../common/_base";
 
-gx-video {
-  /**
-    * @prop --gx-video-height:
-    * Set the height of the control from the video container or the control itself.
-    * (100% by default)
-  */
-  --gx-video-height: 100%;
-
-  /**
-    * @prop --gx-video-width:
-    * Set the width of the control from the video container or the control itself.
-    * (100% by default)
-  */
-  --gx-video-width: 100%;
-
+:host {
   @include visibility(flex);
   width: 100%;
+  height: 100%;
+}
 
-  & > div {
-    height: var(--gx-video-height);
-    width: var(--gx-video-width);
-    display: flex;
-    flex: 1;
-    iframe {
-      flex: 1;
-      border: none;
-    }
-  }
+:host(.disabled) {
+  pointer-events: none;
+}
+
+iframe {
+  flex: 1;
+  border: none;
+}
+
+.gx-video {
+  width: 100%;
+  height: 100%;
 }

--- a/src/components/video/video.scss
+++ b/src/components/video/video.scss
@@ -1,7 +1,5 @@
-@import "../common/_base";
-
 :host {
-  @include visibility(flex);
+  display: flex;
   width: 100%;
   height: 100%;
 }

--- a/src/components/video/video.tsx
+++ b/src/components/video/video.tsx
@@ -2,8 +2,7 @@ import { Component, Element, Host, Prop, h } from "@stencil/core";
 
 import {
   Component as GxComponent,
-  DisableableComponent,
-  VisibilityComponent
+  DisableableComponent
 } from "../common/interfaces";
 
 @Component({
@@ -11,8 +10,7 @@ import {
   styleUrl: "./video.scss",
   tag: "gx-video"
 })
-export class Video
-  implements GxComponent, DisableableComponent, VisibilityComponent {
+export class Video implements GxComponent, DisableableComponent {
   @Element() element: HTMLGxVideoElement;
 
   /**
@@ -21,16 +19,6 @@ export class Video
    * (for example, click event).
    */
   @Prop() readonly disabled = false;
-
-  /**
-   * This attribute lets you specify how this element will behave when hidden.
-   *
-   * | Value        | Details                                                                     |
-   * | ------------ | --------------------------------------------------------------------------- |
-   * | `keep-space` | The element remains in the document flow, and it does occupy space.         |
-   * | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
-   */
-  @Prop() readonly invisibleMode: "collapse" | "keep-space" = "collapse";
 
   /**
    * This attribute is for specifies the src of the video.

--- a/src/components/video/video.tsx
+++ b/src/components/video/video.tsx
@@ -1,34 +1,18 @@
-import {
-  Component,
-  Element,
-  Event,
-  EventEmitter,
-  Prop,
-  h
-} from "@stencil/core";
+import { Component, Element, Host, Prop, h } from "@stencil/core";
 
 import {
-  ClickableComponent,
   Component as GxComponent,
   DisableableComponent,
   VisibilityComponent
 } from "../common/interfaces";
 
 @Component({
-  shadow: false,
+  shadow: true,
   styleUrl: "./video.scss",
   tag: "gx-video"
 })
 export class Video
-  implements
-    GxComponent,
-    ClickableComponent,
-    DisableableComponent,
-    VisibilityComponent {
-  constructor() {
-    this.handleClick = this.handleClick.bind(this);
-  }
-
+  implements GxComponent, DisableableComponent, VisibilityComponent {
   @Element() element: HTMLGxVideoElement;
 
   /**
@@ -60,27 +44,25 @@ export class Video
     @Prop() lazyLoad = true;
   */
 
-  /**
-   * Emitted when the element is clicked.
-   */
-  @Event() gxClick: EventEmitter;
-
-  private handleClick(event: UIEvent) {
-    this.gxClick.emit(event);
-    event.preventDefault();
-  }
-
   private parseYoutubeSrc(src) {
     const domainIdArray = src.split("watch?v=");
     return `${domainIdArray[0]}embed/${domainIdArray[1]}`;
   }
 
+  private isYoutubeVideo = () => this.src.indexOf("youtube.com") !== -1;
+
   render() {
-    const handleClick = !this.disabled ? this.handleClick : null;
     return (
-      <div class="gxVideoContainer" onClick={handleClick}>
-        <iframe src={this.parseYoutubeSrc(this.src)} />
-      </div>
+      <Host
+        aria-disabled={this.disabled ? "true" : undefined}
+        class={{ disabled: this.disabled }}
+      >
+        {this.isYoutubeVideo() ? (
+          <iframe class="gx-video" src={this.parseYoutubeSrc(this.src)} />
+        ) : (
+          <video class="gx-video" controls src={this.src}></video>
+        )}
+      </Host>
     );
   }
 }


### PR DESCRIPTION
**Changes we propose in this PR**:
 - Added support for other video publishers (besides YouTube) and single video files.

 - Added support for Shadow DOM.

 - Removed the `gxClick` event as it is not supported by the Angular Generator.

 - Improved accessibility when the `gx-video` is `disabled`.

 - The HTML and CSS have been simplified.

 - Removed Invisible Mode property in `gx-video`.

[issue: 96024](https://issues.genexus.com/viewissue.aspx?96024)