### PR TITLE
Fix for Header Row Pattern not working in some scenarios

### DIFF
--- a/src/components/header-row-pattern-marker/header-row-pattern-marker.scss
+++ b/src/components/header-row-pattern-marker/header-row-pattern-marker.scss
@@ -1,6 +1,7 @@
 :host {
-  display: block;
+  display: flex;
   position: absolute;
+  width: 100%;
   height: 0;
   align-self: flex-end;
 }


### PR DESCRIPTION
**Changes we propose in this PR**:
 - `issue: 100484` Fix for Header Row Pattern not working in some scenarios. 
   The HRP was not working when the parent cell had a different  `align` than `"center"`.

[issue: 100484](https://issues.genexus.com/viewissue.aspx?100484)