### PR TITLE
Fixes for gx-grid-horizontal and gx-tab controls

### DIFF
--- a/src/components/grid-horizontal/grid-horizontal.scss
+++ b/src/components/grid-horizontal/grid-horizontal.scss
@@ -10,17 +10,27 @@ gx-grid-horizontal {
    */
   --gx-overflow-style: #{$default-overflow-style};
 
-  @include visibility(flex);
+  // With "display: grid" we ensure that the layout doesn't break when using
+  // relative size columns in the parent gx-table
+  @include visibility(grid);
+  grid-template-rows: 1fr min-content 0;
+
+  // Show the loading on grid load
+  &.gx-grid-initial-load {
+    grid-template-rows: 0 1fr;
+  }
 
   & > .gx-grid-horizontal-content {
     display: flex;
     position: relative;
-    flex: 1;
+    width: 100%;
+  }
 
-    & > .swiper-wrapper {
-      position: absolute;
-      height: fit-content;
-    }
+  // When the horizontal grid does not have auto grow, its content must not
+  // stretch the grid height
+  & > .gx-grid-horizontal--no-auto-grow > .swiper-wrapper {
+    position: absolute;
+    inset: 0;
   }
 
   & > [slot="grid-empty-loading-placeholder"] {

--- a/src/components/grid-horizontal/grid-horizontal.tsx
+++ b/src/components/grid-horizontal/grid-horizontal.tsx
@@ -263,7 +263,7 @@ export class GridHorizontal
     );
     this.scrollableContainer.classList.add("swiper-wrapper");
 
-    window.requestAnimationFrame(() => this.ensureSwiper());
+    this.ensureSwiper();
     GridBaseHelper.init(this);
   }
 

--- a/src/components/grid-horizontal/grid-horizontal.tsx
+++ b/src/components/grid-horizontal/grid-horizontal.tsx
@@ -34,10 +34,6 @@ export class GridHorizontal
   private swiper: Swiper = null;
   private fillMode: "column" | "row" = "row";
 
-  private needForRAF = true; // To prevent redundant RAF (request animation frame) calls
-
-  private resizeObserver: ResizeObserver = null;
-
   // Refs
   private horizontalGridContent: HTMLDivElement = null;
   private scrollableContainer: HTMLElement = null;
@@ -109,7 +105,7 @@ export class GridHorizontal
   /**
    * Specifies the orientation mode.
    */
-  @Prop() orientation: "portrait" | "landscape" = "portrait";
+  @Prop({ mutable: true }) orientation: "portrait" | "landscape" = "portrait";
 
   /**
    * If `true`, show the pagination buttons.
@@ -269,11 +265,6 @@ export class GridHorizontal
 
     window.requestAnimationFrame(() => this.ensureSwiper());
     GridBaseHelper.init(this);
-
-    // Implement auto grow
-    if (this.autoGrow) {
-      this.connectResizeObserver();
-    }
   }
 
   componentDidUpdate() {
@@ -283,12 +274,6 @@ export class GridHorizontal
   disconnectedCallback() {
     if (this.isInitialized()) {
       this.swiper.destroy(true, true);
-    }
-
-    // eslint-disable-next-line @stencil/strict-boolean-conditions
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect();
-      this.resizeObserver = null;
     }
   }
 
@@ -443,26 +428,6 @@ export class GridHorizontal
     this.swiper.allowSlideNext = !lock;
     this.swiper.allowSlidePrev = !lock;
     this.swiper.allowTouchMove = !lock;
-  }
-
-  private connectResizeObserver() {
-    this.resizeObserver = new ResizeObserver(() => {
-      if (!this.needForRAF) {
-        return;
-      }
-      this.needForRAF = false; // No need to call RAF up until next frame
-
-      // Update the height in the best moment
-      requestAnimationFrame(() => {
-        this.needForRAF = true; // RAF now consumes the movement instruction so a new one can come
-
-        // Update the height of the horizontal content container, because the
-        // scrollableContainer has "position: absolute"
-        this.horizontalGridContent.style.height = `${this.scrollableContainer.scrollHeight}px`;
-      });
-    });
-
-    this.resizeObserver.observe(this.scrollableContainer);
   }
 
   private ensureSwiper(orientationDidChange = false): boolean {
@@ -642,25 +607,13 @@ export class GridHorizontal
     return { ...swiperOptions, ...this.options, ...mergedEventOptions };
   }
 
-  private getViewPortHeightIfColumnFill() {
-    let height = null;
-
-    if (this.autoGrow || this.fillMode === "row") {
-      return height;
-    }
-    //When 'column' it uses flex-direction: column layout which requires specified height on swiper-container.
-    height = this.element.parentElement.offsetHeight;
-  }
-
   render() {
-    const height = this.getViewPortHeightIfColumnFill();
     const hostData = GridBaseHelper.hostData(this);
 
     return (
       <Host
         {...hostData}
         style={{
-          height: height,
           "--rows":
             this.orientation === "portrait"
               ? this.rows.toString()
@@ -669,7 +622,10 @@ export class GridHorizontal
       >
         {[
           <div
-            class="gx-grid-horizontal-content swiper-container"
+            class={{
+              "gx-grid-horizontal-content swiper-container": true,
+              "gx-grid-horizontal--no-auto-grow": !this.autoGrow
+            }}
             ref={el => (this.horizontalGridContent = el as HTMLDivElement)}
           >
             <slot name="grid-content" />

--- a/src/components/tab/tab.scss
+++ b/src/components/tab/tab.scss
@@ -54,7 +54,7 @@
   @include elevation();
 
   // Implement tabs position
-  grid-template-rows: minmax(auto, max-content);
+  grid-template-rows: min-content 1fr;
 
   flex: 1;
   width: 100%;
@@ -76,14 +76,11 @@
   order: var(--gx-tabs-position--order);
 
   height: var(--tab-strip-height);
-  overflow: hidden;
+  overflow-x: auto; // Fix for Mozilla, because it only accepts: visible, hidden, auto or scroll
+  overflow-x: overlay;
+
   white-space: nowrap;
   transition: box-shadow $transition-duration;
-
-  &:hover {
-    overflow-x: auto; // Fix for Mozilla, because it only accepts: visible, hidden, auto or scroll
-    overflow-x: overlay;
-  }
 
   // - - - - - - - - - - - - - - - -
   //     Scrollbar customization

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -76,7 +76,7 @@ export class Tab
    * | `scoll`      | Allows scrolling the tab control when the number of tabs exceeds the screen width. |
    * | `fixed-size` | Tabs are fixed size. Used with any amount of tabs.                                 |
    */
-  @Prop() tabsDistribution: "scroll" | "fixed-size" = "scroll";
+  @Prop() readonly tabsDistribution: "scroll" | "fixed-size" = "scroll";
 
   /**
    * Fired when the active tab is changed


### PR DESCRIPTION
**Changes we propose in this PR**:
 - `issue: 101250` Fix for AutoGrow in Horizontal Grid.
   - The `gx-grid-horizontal` control will no longer set a resize observer to measure its content size to implement auto-grow.

   - By using `display: grid` in the host container, it is no longer necessary to have `height: fit-content` in the content.

 - Fix for Horizontal Grid crashing on heavy layouts.
 The Horizontal Grid was crashing on heavy layouts as the Window reference did not exist in some occasions. For example, having 10 Grids in the Window caused this issue.

 - `issue: 101263` Fix for tab strip not showing in certain scenarios.
 When the `gx-tab` parent container has less height than the `gx-tab` control, the tab strip was not displayed.

_Summary of issues_:
[issue: 101250](https://issues.genexus.com/viewissue.aspx?101250)
[issue: 101263](https://issues.genexus.com/viewissue.aspx?101263)
