### PR TITLE
Improve linter settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,8 +20,8 @@ module.exports = {
     eqeqeq: ["error", "always", { null: "ignore" }], // Require the use of === and !==   "ignore" -------> Do not apply this rule to null
     "no-console": "warn", // Warning when using console.log, console.warn or console.error
     "no-debugger": "error", // Error when using debugger;
-    "no-empty": "error", // Disallow empty block statements
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
+    "no-empty": "error", // Disallow empty block statements
     "no-sequences": "error", // Disallow comma operators
     "no-undef": "off", // Allows defining undefined variables
     "no-unneeded-ternary": "error", // Disallow ternary operators when simpler alternatives exist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
     "no-empty": "error", // Disallow empty block statements
+    "no-nested-ternary": "warn", // Warns the use of nested ternary expressions
     "no-sequences": "error", // Disallow comma operators
     "no-undef": "off", // Allows defining undefined variables
     "no-unneeded-ternary": "error", // Disallow ternary operators when simpler alternatives exist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     camelcase: "warn", // Enforce camelcase naming convention
     curly: "error", // Enforce consistent brace style for all control statements
     eqeqeq: ["error", "always", { null: "ignore" }], // Require the use of === and !==   "ignore" -------> Do not apply this rule to null
+    "max-depth": ["warn", 3], // Enforce a maximum depth that blocks can be nested. Many developers consider code difficult to read if blocks are nested beyond a certain depth
     "no-console": "warn", // Warning when using console.log, console.warn or console.error
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements
     "no-empty": "error", // Disallow empty block statements
+    "no-lonely-if": "error", // Disallow if statements as the only statement in else blocks
     "no-nested-ternary": "warn", // Warns the use of nested ternary expressions
     "no-sequences": "error", // Disallow comma operators
     "no-undef": "off", // Allows defining undefined variables

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     curly: "error", // Enforce consistent brace style for all control statements
     eqeqeq: ["error", "always", { null: "ignore" }], // Require the use of === and !==   "ignore" -------> Do not apply this rule to null
     "max-depth": ["warn", 3], // Enforce a maximum depth that blocks can be nested. Many developers consider code difficult to read if blocks are nested beyond a certain depth
+    "no-alert": "error", // Disallow the use of alert, confirm, and prompt
     "no-console": "warn", // Warning when using console.log, console.warn or console.error
     "no-debugger": "error", // Error when using debugger;
     "no-duplicate-case": "error", // This rule disallows duplicate test expressions in case clauses of switch statements

--- a/src/components/common/events/swipeable.ts
+++ b/src/components/common/events/swipeable.ts
@@ -38,15 +38,14 @@ export function makeSwipeable(comp: Swipeable) {
         // swiped right
         comp.swipeRight.emit(event);
       }
-    } else {
+
       // sliding vertically
-      if (diffY > 0) {
-        // swiped up
-        comp.swipeUp.emit(event);
-      } else {
-        // swiped down
-        comp.swipeDown.emit(event);
-      }
+    } else if (diffY > 0) {
+      // swiped up
+      comp.swipeUp.emit(event);
+    } else {
+      // swiped down
+      comp.swipeDown.emit(event);
     }
 
     initialX = null;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -163,19 +163,16 @@ export class Select implements FormComponent {
         // initialized as checked
         option.selected = false;
       }
-    } else {
-      // if the select does not have a value
-      // let's look for options initialized as checked
-      if (option.selected) {
-        // this option was initialized as checked,
-        // so let's set the select's value
-        // equals to the checked option value
-        this.value = option.value;
-      }
-      // If there is no option checked
-      // and no value was set in the select,
-      // it will keep undefined until any
-      // change or checked option
+
+      // If the select does not have a value let's look for options initialized
+      // as checked
+    } else if (option.selected) {
+      // This option was initialized as checked, so let's set the select's
+      // value equals to the checked option value
+      this.value = option.value;
+
+      // If there is no option checked and no value was set in the select, it
+      // will keep undefined until any change or checked option
     }
     this.updateOptions(this.getChildOptions());
   }


### PR DESCRIPTION
**Changes we propose in this PR**:
  - `"max-depth": ["warn", 3]` Enforce a maximum depth that blocks can be nested.
 https://eslint.org/docs/latest/rules/max-depth

  - `"no-nested-ternary": "warn"` Warns the use of nested ternary expressions.
 https://eslint.org/docs/latest/rules/no-nested-ternary

  - `"no-lonely-if": "error"` Disallow if statements as the only statement in else blocks.
 https://eslint.org/docs/latest/rules/no-lonely-if

  - `"no-alert": "error"` Disallow the use of alert, confirm, and prompt
  https://eslint.org/docs/latest/rules/no-alert