### PR TITLE
Use native lazy loading for `gx-image`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@types/resize-observer-browser": "^0.1.7",
         "@types/swiper": "^5.4.0",
         "custom-pinch-zoom-element": "^1.2.8",
-        "lazysizes": "^5.3.2",
         "leaflet": "^1.3.4",
         "leaflet-draw": "^1.0.4",
         "leaflet.markercluster": "^1.5.3",
@@ -5861,11 +5860,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/lazysizes": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.3.2.tgz",
-      "integrity": "sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg=="
     },
     "node_modules/leaflet": {
       "version": "1.9.3",
@@ -13506,11 +13500,6 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
-    },
-    "lazysizes": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/lazysizes/-/lazysizes-5.3.2.tgz",
-      "integrity": "sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg=="
     },
     "leaflet": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/resize-observer-browser": "^0.1.7",
     "@types/swiper": "^5.4.0",
     "custom-pinch-zoom-element": "^1.2.8",
-    "lazysizes": "^5.3.2",
     "leaflet": "^1.3.4",
     "leaflet-draw": "^1.0.4",
     "leaflet.markercluster": "^1.5.3",

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -26,10 +26,6 @@ gx-image {
     }
   }
 
-  &.gx-img-lazyloading {
-    overflow: hidden;
-  }
-
   // gx-image with auto-grow = FALSE
   &.gx-img-no-auto-grow {
     overflow-y: hidden; // Vertical overflow is hidden if auto-grow = False
@@ -79,40 +75,25 @@ gx-image {
     background-repeat: repeat;
   }
 
-  .gx-lazyload:not([src]) {
-    visibility: hidden;
-  }
-
-  .gx-lazyloading {
-    display: none;
-  }
-
-  .gx-lazyloading + .gx-image-loading-indicator,
-  .gx-lazyloading + .gx-image-loading-indicator:after {
-    display: var(--image-loading-indicator, inline-block);
-    width: 2em;
-    height: 2em;
-    border-radius: 50%;
-  }
-
-  .gx-lazyloading + .gx-image-loading-indicator {
+  // - - - - - - - - - - - - - - - -
+  //        Loading indicator
+  // - - - - - - - - - - - - - - - -
+  .gx-lazy-loading-image::before {
     $center-loading: calc(50% - 1em);
 
+    content: "";
+    display: var(--image-loading-indicator, inline-block);
     position: absolute;
     inset-block-start: $center-loading;
     inset-inline-start: $center-loading;
+    width: 2em;
+    height: 2em;
+    border-radius: 50%;
     font-size: 0.625em; // Used to set the default size of the loading indicator
-    text-indent: -9999em;
-    border-top: 0.3em solid rgba(0, 0, 0, 0.2);
-    border-right: 0.3em solid rgba(0, 0, 0, 0.2);
-    border-bottom: 0.3em solid rgba(0, 0, 0, 0.2);
-    border-left: 0.3em solid #aaa;
+    border: 0.3em solid #00000033;
+    border-inline-start-color: #aaa;
     transform: translateZ(0);
     animation: gx-image-loading 1.1s infinite linear;
-  }
-
-  .gx-lazyloaded + .gx-image-loading-indicator {
-    display: none;
   }
 }
 
@@ -233,11 +214,10 @@ gx-image {
 
 @keyframes gx-image-loading {
   0% {
-    -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
   }
+
   100% {
-    -webkit-transform: rotate(360deg);
     transform: rotate(360deg);
   }
 }

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -10,16 +10,11 @@ import {
 } from "../common/highlightable";
 
 import { cssVariablesWatcher } from "../common/css-variables-watcher";
-import lazySizes from "lazysizes";
 
 // Class transforms
 import { getClasses } from "../common/css-transforms/css-transforms";
 
-const LAZY_LOAD_CLASS = "gx-lazyload";
-const LAZY_LOADING_CLASS = "gx-lazyloading";
-const LAZY_LOADED_CLASS = "gx-lazyloaded";
-
-const lazyLoadedImages = new Set<string>();
+const LAZY_LOADING_CLASS = "gx-lazy-loading-image";
 
 @Component({
   shadow: false,
@@ -48,10 +43,14 @@ export class Image
 
     this.handleClick = this.handleClick.bind(this);
     this.handleImageLoad = this.handleImageLoad.bind(this);
-
-    this.handleLazyLoaded = this.handleLazyLoaded.bind(this);
-    document.addEventListener("lazyloaded", this.handleLazyLoaded);
   }
+
+  /**
+   * `true` if the image has been loaded
+   */
+  private imageDidLoad = false;
+
+  private innerImageContainer: HTMLDivElement = null;
 
   @Element() element: HTMLGxImageElement;
 
@@ -138,23 +137,22 @@ export class Image
     }
   }
 
-  /**
-   * `true` if the image has been loaded
-   */
-  private imageDidLoad = false;
-
-  private innerImageContainer: HTMLDivElement = null;
-
   private handleImageLoad(event: UIEvent) {
-    const img = event.target as HTMLImageElement;
+    if (this.imageDidLoad) {
+      return;
+    }
+    this.imageDidLoad = true;
     // if (!this.autoGrow) {
     //   // Some image formats do not specify intrinsic dimensions. The naturalWidth property returns 0 in those cases.
     //   if (img.naturalWidth !== 0) {
     //   }
     // }
+
+    const img = event.target as HTMLImageElement;
+
     img.style.setProperty("display", "block");
+    img.parentElement.classList.remove(LAZY_LOADING_CLASS);
     img.style.removeProperty("opacity");
-    this.imageDidLoad = true;
   }
 
   componentDidLoad() {
@@ -162,17 +160,14 @@ export class Image
   }
 
   disconnectedCallback() {
-    document.removeEventListener("lazyloaded", this.handleLazyLoaded);
     this.innerImageContainer = null;
   }
 
   render() {
-    const shouldLazyLoad = this.shouldLazyLoad();
-
     // Styling for gx-image control.
     const classes = getClasses(this.cssClass);
 
-    const withoutAutogrow = this.scaleType !== "tile" && !this.autoGrow;
+    const withoutAutoGrow = this.scaleType !== "tile" && !this.autoGrow;
 
     const shouldRenderTheImg = this.srcset || this.src;
 
@@ -181,7 +176,6 @@ export class Image
           <img
             class={{
               "inner-image": true,
-              [LAZY_LOAD_CLASS]: shouldLazyLoad,
               "gx-image-tile": this.scaleType === "tile"
             }}
             style={{
@@ -189,19 +183,13 @@ export class Image
                 this.scaleType === "tile" ? `url(${this.src})` : null,
               opacity: !this.imageDidLoad ? "0" : null
             }}
+            alt={this.alt}
+            loading="lazy"
+            src={this.src || undefined}
+            srcset={this.srcset || undefined}
             onClick={this.handleClick}
             onLoad={this.handleImageLoad}
-            // With lazy loading
-            data-src={shouldLazyLoad && this.src ? this.src : undefined}
-            data-srcset={
-              shouldLazyLoad && this.srcset ? this.srcset : undefined
-            }
-            // Without lazy loading
-            src={!shouldLazyLoad && this.src ? this.src : undefined}
-            srcset={!shouldLazyLoad && this.srcset ? this.srcset : undefined}
-            alt={this.alt}
-          />,
-          <span class="gx-image-loading-indicator" />
+          />
         ]
       : [];
 
@@ -210,8 +198,8 @@ export class Image
         class={{
           [classes.vars]: true,
           disabled: this.disabled,
-          "gx-img-lazyloading": shouldLazyLoad,
-          "gx-img-no-auto-grow": withoutAutogrow
+          "gx-img-no-auto-grow": withoutAutoGrow,
+          [LAZY_LOADING_CLASS]: !withoutAutoGrow && !this.imageDidLoad
         }}
       >
         <div
@@ -229,46 +217,22 @@ export class Image
           tabindex={this.highlightable && !this.disabled ? "0" : undefined}
           ref={el => (this.innerImageContainer = el as HTMLDivElement)}
         >
-          {withoutAutogrow ? (
-            <div class="gx-image-no-auto-grow-container">{body}</div>
+          {withoutAutoGrow ? (
+            <div
+              class={{
+                "gx-image-no-auto-grow-container": true,
+                [LAZY_LOADING_CLASS]: !this.imageDidLoad
+              }}
+            >
+              {body}
+            </div>
           ) : (
             body
           )}
+
           {this.showImagePickerButton && <slot />}
         </div>
       </Host>
     );
   }
-
-  private shouldLazyLoad(): boolean {
-    // Lazy load is disabled
-    if (!this.lazyLoad) {
-      return false;
-    }
-
-    // Do not lazy load already loaded images
-    if (lazyLoadedImages.has(this.srcset) || lazyLoadedImages.has(this.src)) {
-      return false;
-    }
-
-    const img: HTMLImageElement = this.element.querySelector("img");
-    return img === null || img.classList.contains(LAZY_LOAD_CLASS);
-  }
-
-  private handleLazyLoaded(event: CustomEvent) {
-    const img: HTMLImageElement = this.element.querySelector("img");
-
-    if (event.target === img) {
-      this.element.classList.remove("gx-img-lazyloading");
-
-      const imageSrc = this.srcset || this.src;
-
-      // Store the srcset or src of the lazy loaded image
-      lazyLoadedImages.add(imageSrc);
-    }
-  }
 }
-
-lazySizes.cfg.lazyClass = LAZY_LOAD_CLASS;
-lazySizes.cfg.loadingClass = LAZY_LOADING_CLASS;
-lazySizes.cfg.loadedClass = LAZY_LOADED_CLASS;


### PR DESCRIPTION
The `gx-image` control will no longer use the lazysizes JavaScript library to implement the lazy loading, but instead will use the browser's native implementation, which is faster.

[issue: 102575](https://issues.genexus.com/viewissue.aspx?102575)