### PR TITLE
Refactoring for `gx-textblock` implementation

### DIFF
--- a/src/components/common/_alignment-with-shadow-dom.scss
+++ b/src/components/common/_alignment-with-shadow-dom.scss
@@ -2,18 +2,21 @@
 @mixin text-align-with-shadow-DOM() {
   &[align="left"] {
     > gx-textblock {
+      justify-content: flex-start;
       text-align: start;
     }
   }
 
   &[align="center"] {
     > gx-textblock {
+      justify-content: center;
       text-align: center;
     }
   }
 
   &[align="right"] {
     > gx-textblock {
+      justify-content: flex-end;
       text-align: end;
     }
   }
@@ -22,21 +25,21 @@
 /// Helper mixin to ease vertical alignment of shadow DOM components
 @mixin valign-with-shadow-DOM() {
   &[valign="top"] {
-    > ::part(valign),
+    > gx-textblock,
     ::part(gx-valign) {
       align-items: flex-start;
     }
   }
 
   &[valign="middle"] {
-    > ::part(valign),
+    > gx-textblock,
     ::part(gx-valign) {
       align-items: center;
     }
   }
 
   &[valign="bottom"] {
-    > ::part(valign),
+    > gx-textblock,
     ::part(gx-valign) {
       align-items: flex-end;
     }

--- a/src/components/common/_base.scss
+++ b/src/components/common/_base.scss
@@ -70,22 +70,6 @@
 }
 
 @mixin line-clamp() {
-  .gx-line-clamp {
-    display: -webkit-box;
-    position: absolute;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: var(--max-lines);
-    overflow: hidden;
-  }
-
-  // Used to measure the line height, in order to make the lines clampable
-  .line-measuring {
-    visibility: hidden;
-    position: absolute;
-  }
-}
-
-@mixin line-clamp-2() {
   // Used to measure the box height, in order to make the lines clampable
   .height-measuring {
     display: flex;

--- a/src/components/edit/edit.scss
+++ b/src/components/edit/edit.scss
@@ -10,7 +10,7 @@
 }
 
 @include box-sizing();
-@include line-clamp-2();
+@include line-clamp();
 
 :host {
   /**

--- a/src/components/edit/edit.scss
+++ b/src/components/edit/edit.scss
@@ -189,7 +189,7 @@
 // - - - - - - - - - - - - - - - -
 //            Auto Fill
 // - - - - - - - - - - - - - - - -
-.content {
+.autofill {
   // Dummy animation to trigger the onAnimationStart event
   &:-webkit-autofill {
     animation: AutoFillStart 0.000001s;

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -52,6 +52,7 @@ const PART_CONTENT = "gx-edit__content";
 /**
  * @part gx-edit__content - The main content displayed in the control. This part only applies when `format="Text"`.
  * @part gx-edit__date-placeholder - A placeholder displayed when the control is editable (`readonly="false"`), has no value set, and its type is `"datetime-local" | "date" | "time"`.
+ * @part gx-edit__hidden-multiline - The auxiliary content rendered in the control to implement the auto-grow. This part only applies when `format="Text"`, `multiline="true"` and `readonly="false"`.
  * @part gx-edit__html-container - The container of the main content displayed in the control. This part only applies when `format="HTML"`.
  * @part gx-edit__html-content - The main content displayed in the control. This part only applies when `format="HTML"`.
  * @part gx-edit__trigger-button - The trigger button displayed on the right side of the control when `show-trigger="true"`.
@@ -473,7 +474,12 @@ export class Edit
                   ></textarea>,
 
                   // The space at the end of the value is necessary to correctly display the enters
-                  <div class="hidden-multiline">{this.value} </div>
+                  <div
+                    class="hidden-multiline"
+                    part="gx-edit__hidden-multiline"
+                  >
+                    {this.value}{" "}
+                  </div>
                 ]
               ) : (
                 <input

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -47,6 +47,8 @@ const MIN_DATE_VALUE: { [key: string]: string } = {
   "datetime-local": "0001-01-01T00:00:00"
 };
 
+const PART_CONTENT = "gx-edit__content";
+
 /**
  * @part gx-edit__content - The main content displayed in the control. This part only applies when `format="Text"`.
  * @part gx-edit__date-placeholder - A placeholder displayed when the control is editable (`readonly="false"`), has no value set, and its type is `"datetime-local" | "date" | "time"`.
@@ -428,7 +430,6 @@ export class Edit
           ? [
               <this.readonlyTag
                 aria-disabled={this.disabled ? "true" : undefined}
-                aria-label={this.labelCaption || undefined}
                 class={{
                   content: this.format === "Text",
                   "html-container": this.format === "HTML",
@@ -437,7 +438,7 @@ export class Edit
                 }}
                 part={
                   this.format === "Text"
-                    ? "gx-edit__content"
+                    ? PART_CONTENT
                     : "gx-edit__html-container gx-valign"
                 }
                 style={
@@ -466,7 +467,7 @@ export class Edit
                   <textarea
                     {...attrs}
                     class="content"
-                    part="gx-edit__content"
+                    part={PART_CONTENT}
                     value={this.value}
                     ref={el => (this.inputRef = el as HTMLElement)}
                   ></textarea>,
@@ -481,7 +482,7 @@ export class Edit
                     content: true,
                     "null-date": this.isDateType && !this.value
                   }}
-                  part="gx-edit__content"
+                  part={PART_CONTENT}
                   type={this.type}
                   value={this.value}
                   ref={el => (this.inputRef = el as HTMLElement)}

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -466,7 +466,7 @@ export class Edit
                 [
                   <textarea
                     {...attrs}
-                    class="content"
+                    class="content autofill"
                     part={PART_CONTENT}
                     value={this.value}
                     ref={el => (this.inputRef = el as HTMLElement)}
@@ -479,7 +479,7 @@ export class Edit
                 <input
                   {...attrs}
                   class={{
-                    content: true,
+                    "content autofill": true,
                     "null-date": this.isDateType && !this.value
                   }}
                   part={PART_CONTENT}

--- a/src/components/edit/readme.md
+++ b/src/components/edit/readme.md
@@ -74,13 +74,14 @@ Type: `Promise<string>`
 
 ## Shadow Parts
 
-| Part                          | Description                                                                                                                                          |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"gx-edit__content"`          | The main content displayed in the control. This part only applies when `format="Text"`.                                                              |
-| `"gx-edit__date-placeholder"` | A placeholder displayed when the control is editable (`readonly="false"`), has no value set, and its type is `"datetime-local" \| "date" \| "time"`. |
-| `"gx-edit__html-container"`   | The container of the main content displayed in the control. This part only applies when `format="HTML"`.                                             |
-| `"gx-edit__html-content"`     | The main content displayed in the control. This part only applies when `format="HTML"`.                                                              |
-| `"gx-edit__trigger-button"`   | The trigger button displayed on the right side of the control when `show-trigger="true"`.                                                            |
+| Part                          | Description                                                                                                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"gx-edit__content"`          | The main content displayed in the control. This part only applies when `format="Text"`.                                                                           |
+| `"gx-edit__date-placeholder"` | A placeholder displayed when the control is editable (`readonly="false"`), has no value set, and its type is `"datetime-local" \| "date" \| "time"`.              |
+| `"gx-edit__hidden-multiline"` | The auxiliary content rendered in the control to implement the auto-grow. This part only applies when `format="Text"`, `multiline="true"` and `readonly="false"`. |
+| `"gx-edit__html-container"`   | The container of the main content displayed in the control. This part only applies when `format="HTML"`.                                                          |
+| `"gx-edit__html-content"`     | The main content displayed in the control. This part only applies when `format="HTML"`.                                                                           |
+| `"gx-edit__trigger-button"`   | The trigger button displayed on the right side of the control when `show-trigger="true"`.                                                                         |
 
 ## CSS Custom Properties
 

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -169,29 +169,28 @@ export class Image
 
     const withoutAutoGrow = this.scaleType !== "tile" && !this.autoGrow;
 
-    const shouldRenderTheImg = this.srcset || this.src;
+    const imageSrc = this.srcset || this.src;
+    const shouldAddLazyLoadingClass = !this.imageDidLoad && !!imageSrc;
 
-    const body = shouldRenderTheImg
-      ? [
-          <img
-            class={{
-              "inner-image": true,
-              "gx-image-tile": this.scaleType === "tile"
-            }}
-            style={{
-              backgroundImage:
-                this.scaleType === "tile" ? `url(${this.src})` : null,
-              opacity: !this.imageDidLoad ? "0" : null
-            }}
-            alt={this.alt}
-            loading="lazy"
-            src={this.src || undefined}
-            srcset={this.srcset || undefined}
-            onClick={this.handleClick}
-            onLoad={this.handleImageLoad}
-          />
-        ]
-      : [];
+    const body = !!imageSrc && (
+      <img
+        class={{
+          "inner-image": true,
+          "gx-image-tile": this.scaleType === "tile"
+        }}
+        style={{
+          backgroundImage:
+            this.scaleType === "tile" ? `url(${this.src})` : null,
+          opacity: !this.imageDidLoad ? "0" : null
+        }}
+        alt={this.alt}
+        loading="lazy"
+        src={this.src || undefined}
+        srcset={this.srcset || undefined}
+        onClick={this.handleClick}
+        onLoad={this.handleImageLoad}
+      />
+    );
 
     return (
       <Host
@@ -199,7 +198,7 @@ export class Image
           [classes.vars]: true,
           disabled: this.disabled,
           "gx-img-no-auto-grow": withoutAutoGrow,
-          [LAZY_LOADING_CLASS]: !withoutAutoGrow && !this.imageDidLoad
+          [LAZY_LOADING_CLASS]: !withoutAutoGrow && shouldAddLazyLoadingClass
         }}
       >
         <div
@@ -221,7 +220,7 @@ export class Image
             <div
               class={{
                 "gx-image-no-auto-grow-container": true,
-                [LAZY_LOADING_CLASS]: !this.imageDidLoad
+                [LAZY_LOADING_CLASS]: shouldAddLazyLoadingClass
               }}
             >
               {body}

--- a/src/components/textblock/readme.md
+++ b/src/components/textblock/readme.md
@@ -18,19 +18,25 @@ A SASS mixin called `gx-textblock` is provided in `theming/theming-mixins.scss` 
 | --------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------ |
 | `cssClass`      | `css-class`      | A CSS class to set as the `gx-textblock` element class.                                                                                                                                                                                                                                                                                                                                      | `string`                     | `undefined`  |
 | `disabled`      | `disabled`       | This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).                                                                                                                                                                                                                                     | `boolean`                    | `false`      |
-| `format`        | `format`         | It specifies the format that will have the textblock control. If `format` = `HTML`, the textblock control works as an HTML div and the innerHTML will be the same as the `inner` property specifies. If `format` = `Text`, the control works as a normal textblock control and it is affected by most of the defined properties.                                                             | `"HTML" \| "Text"`           | `"Text"`     |
+| `format`        | `format`         | It specifies the format that will have the textblock control. - If `format` = `HTML`, the textblock control works as an HTML div and the innerHTML will be taken from the default slot. - If `format` = `Text`, the control works as a normal textblock control and it is affected by most of the defined properties.                                                                        | `"HTML" \| "Text"`           | `"Text"`     |
 | `highlightable` | `highlightable`  | True to highlight control when an action is fired.                                                                                                                                                                                                                                                                                                                                           | `boolean`                    | `false`      |
-| `href`          | `href`           | This attribute lets you specify an URL. If a URL is specified, the textblock acts as an anchor.                                                                                                                                                                                                                                                                                              | `""`                         | `""`         |
-| `inner`         | `inner`          | Used as the innerHTML when `format` = `HTML`.                                                                                                                                                                                                                                                                                                                                                | `string`                     | `""`         |
 | `invisibleMode` | `invisible-mode` | This attribute lets you specify how this element will behave when hidden. \| Value \| Details \| \| ------------ \| --------------------------------------------------------------------------- \| \| `keep-space` \| The element remains in the document flow, and it does occupy space. \| \| `collapse` \| The element is removed form the document flow, and it doesn't occupy space. \| | `"collapse" \| "keep-space"` | `"collapse"` |
 | `lineClamp`     | `line-clamp`     | True to cut text when it overflows, showing an ellipsis.                                                                                                                                                                                                                                                                                                                                     | `boolean`                    | `false`      |
 
+## Slots
+
+| Slot | Description                                         |
+| ---- | --------------------------------------------------- |
+|      | The slot for the html content when `format="HTML"`. |
+
 ## Shadow Parts
 
-| Part        | Description |
-| ----------- | ----------- |
-| `"content"` |             |
-| `"valign"`  |             |
+| Part                             | Description                                                                                              |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `"gx-textblock__content"`        | The main content displayed in the control. This part only applies when `format="Text"`.                  |
+| `"gx-textblock__html-container"` | The container of the main content displayed in the control. This part only applies when `format="HTML"`. |
+| `"gx-textblock__html-content"`   | The main content displayed in the control. This part only applies when `format="HTML"`.                  |
+| `"gx-valign"`                    |                                                                                                          |
 
 ## Dependencies
 

--- a/src/components/textblock/textblock.scss
+++ b/src/components/textblock/textblock.scss
@@ -1,19 +1,18 @@
 @import "../common/_base";
 @import "../common/_common-styling-config";
 
+@include box-sizing();
 @include line-clamp();
-@include visibility-shadow-DOM(inline-flex);
-
-:host(.disabled) {
-  pointer-events: none;
-}
+@include visibility-shadow-DOM(flex);
 
 :host {
   --elevation: 0;
   @include elevation();
 
-  flex: 1;
   align-self: stretch;
+  align-items: flex-start;
+  position: relative;
+  width: 100%;
   text-align: start; // Default alignment which supports RTL
 
   // Remove outline of the focus state
@@ -22,14 +21,29 @@
   @include transition-properties();
 }
 
-.gx-textblock-container {
+// - - - - - - - - - - - - - - - - - - - -
+//      Format = "Text" and lineClamp
+// - - - - - - - - - - - - - - - - - - - -
+.content {
+  @include reset-browser-defaults-properties-1();
+
+  position: absolute;
+  inset-inline: 0;
+  padding-inline: inherit;
+}
+
+// - - - - - - - - - - - - - - - - - - - -
+//             Format = "HTML"
+// - - - - - - - - - - - - - - - - - - - -
+.html-container {
   display: flex;
   align-items: flex-start;
-  flex: 1;
   position: relative;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
+}
 
-  & > .gx-textblock-content {
-    width: 100%;
-  }
+.html-content {
+  width: 100%;
 }

--- a/src/components/textblock/textblock.tsx
+++ b/src/components/textblock/textblock.tsx
@@ -18,9 +18,23 @@ import {
 } from "../common/highlightable";
 import { LineClampComponent, makeLinesClampable } from "../common/line-clamp";
 
+import {
+  DISABLED_CLASS,
+  HEIGHT_MEASURING,
+  LINE_CLAMP,
+  LINE_MEASURING
+} from "../../common/reserved-names";
+
 // Class transforms
 import { getClasses } from "../common/css-transforms/css-transforms";
 
+/**
+ * @part gx-textblock__content - The main content displayed in the control. This part only applies when `format="Text"`.
+ * @part gx-textblock__html-container - The container of the main content displayed in the control. This part only applies when `format="HTML"`.
+ * @part gx-textblock__html-content - The main content displayed in the control. This part only applies when `format="HTML"`.
+ *
+ * @slot - The slot for the html content when `format="HTML"`.
+ */
 @Component({
   shadow: true,
   styleUrl: "textblock.scss",
@@ -37,13 +51,15 @@ export class TextBlock
   constructor() {
     makeLinesClampable(
       this,
-      ".gx-textblock-container",
-      ".line-measuring",
+      "." + HEIGHT_MEASURING,
+      "." + LINE_MEASURING,
       true
     );
   }
 
   @Element() element: HTMLGxTextblockElement;
+
+  @State() maxLines = 0;
 
   /**
    * A CSS class to set as the `gx-textblock` element class.
@@ -51,9 +67,27 @@ export class TextBlock
   @Prop() readonly cssClass: string;
 
   /**
-   * This attribute lets you specify an URL. If a URL is specified, the textblock acts as an anchor.
+   * This attribute lets you specify if the element is disabled.
+   * If disabled, it will not fire any user interaction related event
+   * (for example, click event).
    */
-  @Prop() readonly href = "";
+  @Prop({ reflect: true }) readonly disabled = false;
+
+  /**
+   * It specifies the format that will have the textblock control.
+   *
+   *  - If `format` = `HTML`, the textblock control works as an HTML div and
+   *    the innerHTML will be taken from the default slot.
+   *
+   *  - If `format` = `Text`, the control works as a normal textblock control
+   *    and it is affected by most of the defined properties.
+   */
+  @Prop() readonly format: "Text" | "HTML" = "Text";
+
+  /**
+   * True to highlight control when an action is fired.
+   */
+  @Prop() readonly highlightable = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.
@@ -66,104 +100,69 @@ export class TextBlock
   @Prop() readonly invisibleMode: "collapse" | "keep-space" = "collapse";
 
   /**
-   * This attribute lets you specify if the element is disabled.
-   * If disabled, it will not fire any user interaction related event
-   * (for example, click event).
-   */
-  @Prop({ reflect: true }) readonly disabled = false;
-
-  /**
    * True to cut text when it overflows, showing an ellipsis.
    */
   @Prop() readonly lineClamp = false;
 
-  /**
-   * True to highlight control when an action is fired.
-   */
-  @Prop() readonly highlightable = false;
-
-  /**
-   * It specifies the format that will have the textblock control.
-   *
-   * If `format` = `HTML`, the textblock control works as an HTML div and the
-   * innerHTML will be the same as the `inner` property specifies.
-   *
-   * If `format` = `Text`, the control works as a normal textblock control and
-   * it is affected by most of the defined properties.
-   */
-  @Prop() readonly format: "Text" | "HTML" = "Text";
-
-  /**
-   * Used as the innerHTML when `format` = `HTML`.
-   */
-  @Prop() readonly inner: string = "";
-
-  @State() maxLines = 0;
-
   @Listen("click", { capture: true })
   handleClick(event: UIEvent) {
-    event.preventDefault();
     if (this.disabled) {
       event.stopPropagation();
       return;
     }
-  }
-  private shouldLineClamp: boolean;
-
-  componentWillLoad() {
-    this.shouldLineClamp = this.format === "Text" && this.lineClamp;
   }
 
   componentDidLoad() {
     makeHighlightable(this);
   }
 
+  /**
+   * This function is called either when `format="HTML"` or when
+   * `lineClamp="true"`.
+   * @returns The textblock content based on the current state.
+   */
+  private getContent = () =>
+    this.format === "Text" ? (
+      [
+        <div class={LINE_MEASURING}>{"A"}</div>,
+        <div class={HEIGHT_MEASURING}></div>,
+        <p
+          class={`content ${LINE_CLAMP}`}
+          part="gx-textblock__content"
+          style={{ "--max-lines": this.maxLines.toString() }}
+        >
+          <slot />
+        </p>
+      ]
+    ) : (
+      <div class="html-container" part="gx-textblock__html-container gx-valign">
+        <div class="html-content" part="gx-textblock__html-content">
+          <slot />
+        </div>
+      </div>
+    );
+
   render() {
     // Styling for gx-textblock control.
     const classes = getClasses(this.cssClass);
 
-    const body = (
-      <div class="gx-textblock-container" part="valign">
-        {this.lineClamp && <div class="line-measuring">{"A"}</div>}
-        {this.format === "Text" ? (
-          <span
-            class={{
-              "gx-textblock-content": true,
-              "gx-line-clamp": this.shouldLineClamp
-            }}
-            style={
-              this.shouldLineClamp
-                ? {
-                    "--max-lines": this.maxLines.toString()
-                  }
-                : undefined
-            }
-            part="content"
-          >
-            <slot />
-          </span>
-        ) : (
-          <div
-            class="gx-textblock-content"
-            innerHTML={this.inner}
-            part="content"
-          ></div>
-        )}
-      </div>
-    );
+    const justRenderTheSlot = this.format === "Text" && !this.lineClamp;
+    const shouldAddFocus = this.highlightable && !this.disabled;
 
     return (
       <Host
+        role={justRenderTheSlot ? "paragraph" : null}
+        aria-disabled={this.disabled ? "true" : null}
         class={{
           [this.cssClass]: !!this.cssClass,
           [classes.vars]: true,
-          disabled: this.disabled
+          [DISABLED_CLASS]: this.disabled
         }}
-        data-has-action={this.highlightable ? "" : undefined}
+        data-has-action={shouldAddFocus ? "" : undefined}
         // Add focus to the control through sequential keyboard navigation and visually clicking
-        tabindex={this.highlightable && !this.disabled ? "0" : undefined}
+        tabindex={shouldAddFocus ? "0" : undefined}
       >
-        {this.href ? <a href={this.href}>{body}</a> : body}
+        {justRenderTheSlot ? <slot /> : this.getContent()}
       </Host>
     );
   }

--- a/src/global/common.scss
+++ b/src/global/common.scss
@@ -36,12 +36,6 @@ gx-card-header > li:not([slot="low-priority-action"]) > gx-button {
 
   &.without-auto-grow-cell,
   &:not([auto-grow]) {
-    // Used when auto-grow = false in the gx-textblock control to ensure the
-    // content does not overflows
-    & > gx-textblock::part(content) {
-      position: absolute;
-    }
-
     // Used when auto-grow = false and readonly = true in the gx-edit control
     // to ensure the content does not overflows
     & > gx-form-field > .gx-edit--readonly::part(gx-edit__content) {
@@ -50,9 +44,10 @@ gx-card-header > li:not([slot="low-priority-action"]) > gx-button {
       padding-inline: inherit;
     }
 
-    // Used when auto-grow = false and format = HTML in the gx-edit control
-    // to ensure the content does not overflows
-    & > gx-form-field > .gx-edit--readonly::part(gx-edit__html-content) {
+    // Used when auto-grow = false and format = HTML in the gx-edit and
+    // gx-textblock control to ensure the content does not overflows
+    & > gx-form-field > ::part(gx-edit__html-content),
+    & > ::part(gx-textblock__html-content) {
       position: absolute;
     }
 


### PR DESCRIPTION
**Changes we propose in this PR**:
 - `issue: 102650` Refactoring for the `gx-textblock` implementation.
   - Reduced the number of nested tags used to implement the control (less HTML).

   - In addition, reduced the amount of JavaScript needed to implement the `gx-textblock`'s behaviors.

    - Removed `href` and `inner` properties

    - Improved line-clamp implementation.

    - `issue: 102651` The `innerHTML` will be place in the `gx-textblock`'s default slot instead of the shadowRoot content.

  - Minor fixes for the `gx-edit` and `gx-image` controls.

_Summary of issues_:
[issue: 102650](https://issues.genexus.com/viewissue.aspx?102650)
[issue: 102651](https://issues.genexus.com/viewissue.aspx?102651)
