### PR TITLE
Fix performance regression in `gx-table-cell`

### DIFF
--- a/src/components/table-cell/table-cell.tsx
+++ b/src/components/table-cell/table-cell.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Prop, h, Host } from "@stencil/core";
 import { Component as GxComponent } from "../common/interfaces";
 
 @Component({
-  shadow: true,
+  shadow: false,
   tag: "gx-table-cell"
 })
 export class TableCell implements GxComponent {


### PR DESCRIPTION
Remove Shadow DOM from `gx-table-cell` as it was creating two additional DOM Nodes which were causing lower performance on LCP (Largest Contentful Paint) metric.