### PR TITLE
Fix stencil boolean props types

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -38,13 +38,13 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, gxClick event).
      */
-    disabled: false;
+    disabled: boolean;
   }
   interface GxAudio {
     /**
      * This attribute lets you specify if the element is disabled.
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * This attribute is for specifies the src of the audio.
      */
@@ -58,7 +58,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event). If a disabled image has been specified, it will be shown, hiding the base image (if specified).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * This attribute lets you specify the height.
      */
@@ -66,7 +66,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: true;
+    highlightable: boolean;
     /**
      * This attribute lets you specify the relative location of the image to the text.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `above`  | The image is located above the text.                    | | `before` | The image is located before the text, in the same line. | | `after`  | The image is located after the text, in the same line.  | | `below`  | The image is located below the text.                    | | `behind` | The image is located behind the text.                   |
      */
@@ -92,7 +92,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -144,7 +144,7 @@ export namespace Components {
     /**
      * True to show the card header. False to hide it.
      */
-    showHeader: true;
+    showHeader: boolean;
   }
   interface GxCardHeader {
     /**
@@ -176,7 +176,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Returns the id of the inner `input` element (if set).
      */
@@ -184,7 +184,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -192,7 +192,7 @@ export namespace Components {
     /**
      * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.
      */
-    readonly: false;
+    readonly: boolean;
     /**
      * The value when the checkbox is 'off'
      */
@@ -302,7 +302,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Used to define the semantic of the element when `readonly="true"`.
      */
@@ -326,7 +326,7 @@ export namespace Components {
     /**
      * True to cut text when it overflows, showing an ellipsis (only applies when readonly)
      */
-    lineClamp: false;
+    lineClamp: boolean;
     /**
      * Controls if the element accepts multiline text.
      */
@@ -462,7 +462,7 @@ export namespace Components {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows.
      */
-    autoGrow: false;
+    autoGrow: boolean;
     /**
      * This method must be called after new grid data was fetched by the infinite scroller.
      */
@@ -510,7 +510,7 @@ export namespace Components {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows.
      */
-    autoGrow: false;
+    autoGrow: boolean;
     /**
      * This method must be called after new grid data was fetched by the infinite scroller.
      */
@@ -522,7 +522,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -572,7 +572,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -628,11 +628,11 @@ export namespace Components {
     /**
      * If `true`, show the scrollbar.
      */
-    scrollbar: false;
+    scrollbar: boolean;
     /**
      * If `true`, show the pagination buttons (page controller).
      */
-    showPageController: true;
+    showPageController: boolean;
     /**
      * Transition to the next slide.
      * @param speed The transition duration (in ms).
@@ -659,7 +659,7 @@ export namespace Components {
     /**
      * Set to false to enable slides in free mode position.
      */
-    snapToGrid: true;
+    snapToGrid: boolean;
     /**
      * Start auto play.
      */
@@ -697,7 +697,7 @@ export namespace Components {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows. This property is not currently supported in the gx-image-map control.
      */
-    autoGrow: false;
+    autoGrow: boolean;
     /**
      * A CSS class to set as the `gx-grid-image-map` element class.
      */
@@ -804,7 +804,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify the index of the cell. Useful when Inverse Loading is enabled on the grid.
      */
@@ -812,7 +812,7 @@ export namespace Components {
     /**
      * Whether this row is even position or not. This is specially required in Virtual scroll scenarios where the position in the DOM is not the real position in the collection.
      */
-    isRowEven: false;
+    isRowEven: boolean;
     /**
      * Number of Columns to be shown in the grid. Useful when Inverse Loading is enabled on the grid.
      */
@@ -820,13 +820,13 @@ export namespace Components {
     /**
      * True to show horizontal line.
      */
-    showHorizontalLine: false;
+    showHorizontalLine: boolean;
   }
   interface GxGridSmartCss {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows.
      */
-    autoGrow: false;
+    autoGrow: boolean;
     /**
      * This method must be called after new grid data was fetched by the infinite scroller.
      */
@@ -862,7 +862,7 @@ export namespace Components {
     /**
      * Scroll snapping allows to lock the viewport to certain elements or locations after a user has finished scrolling
      */
-    snapToGrid: false;
+    snapToGrid: boolean;
     /**
      * The threshold distance from the bottom of the content to call the `infinite` output event when scrolled. The threshold value can be either a percent, or in pixels. For example, use the value of `10%` for the `infinite` output event to get called when the user has scrolled 10% from the bottom of the page. Use the value `100px` when the scroll is within 100 pixels from the bottom of the page.
      */
@@ -884,7 +884,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
   }
   interface GxHeaderRowPatternMarker {}
   interface GxIcon {
@@ -913,7 +913,7 @@ export namespace Components {
     /**
      * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
      */
-    autoGrow: true;
+    autoGrow: boolean;
     /**
      * A CSS class to set as the `gx-image` element class.
      */
@@ -921,11 +921,11 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -933,7 +933,7 @@ export namespace Components {
     /**
      * True to lazy load the image, when it enters the viewport.
      */
-    lazyLoad: true;
+    lazyLoad: boolean;
     /**
      * This attribute allows specifing how the image is sized according to its container. `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property. The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
      */
@@ -955,7 +955,7 @@ export namespace Components {
     /**
      * If the annotations are activated or not.
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Specifies the `fontFamily` for the texts
      */
@@ -1005,7 +1005,7 @@ export namespace Components {
     /**
      * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
      */
-    autoGrow: true;
+    autoGrow: boolean;
     /**
      * This attribute lets you specify the description of the cancel action button in the modal.
      */
@@ -1021,11 +1021,11 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1033,7 +1033,7 @@ export namespace Components {
     /**
      * True to lazy load the image, when it enters the viewport.
      */
-    lazyLoad: true;
+    lazyLoad: boolean;
     /**
      * This attribute lets you specify the modal title.
      */
@@ -1041,7 +1041,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the image is readonly. If readonly, it will not allow to use the edit button. In fact, the edit button will not be shown.
      */
-    readonly: false;
+    readonly: boolean;
     /**
      * This attribute lets you specify the description of the remove image button in the modal.
      */
@@ -1085,7 +1085,7 @@ export namespace Components {
     /**
      * `false` to hide the bottom target
      */
-    bottomVisible: false;
+    bottomVisible: boolean;
     /**
      * This attribute lets you specify if the header row pattern is enabled in the top navbar.
      */
@@ -1109,7 +1109,7 @@ export namespace Components {
     /**
      * `false` to hide the top target.
      */
-    topVisible: false;
+    topVisible: boolean;
   }
   interface GxLoading {
     /**
@@ -1145,7 +1145,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1426,7 +1426,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if one or two lines will be used to render the navigation bar. Useful when there are links and also actions, to have links in the first line, and actions in the second
      */
-    singleLine: true;
+    singleLine: boolean;
     /**
      * This attribute lets you specify the label for the left target toggle button. Important for accessibility.
      */
@@ -1436,7 +1436,7 @@ export namespace Components {
     /**
      * Indicates if the navbar item is the active one (for example, when the item represents the current page)
      */
-    active: false;
+    active: boolean;
     /**
      * A CSS class to set as the `gx-navbar-item` element class.
      */
@@ -1444,7 +1444,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: true;
+    highlightable: boolean;
     /**
      * This attribute lets you specify the URL of the navbar item.
      */
@@ -1474,7 +1474,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Returns the id of the inner `input` element (if set).
      */
@@ -1550,7 +1550,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1580,7 +1580,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1628,7 +1628,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Returns the id of the inner `input` element (if set).
      */
@@ -1662,7 +1662,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Indicates that the control is selected by default.
      */
@@ -1688,7 +1688,7 @@ export namespace Components {
     /**
      * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * Returns the id of the inner `input` element (if set).
      */
@@ -1718,7 +1718,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1780,11 +1780,11 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1828,7 +1828,7 @@ export namespace Components {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * It specifies the format that will have the textblock control.   - If `format` = `HTML`, the textblock control works as an HTML div and    the innerHTML will be taken from the default slot.   - If `format` = `Text`, the control works as a normal textblock control    and it is affected by most of the defined properties.
      */
@@ -1836,7 +1836,7 @@ export namespace Components {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable: false;
+    highlightable: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -1844,13 +1844,13 @@ export namespace Components {
     /**
      * True to cut text when it overflows, showing an ellipsis.
      */
-    lineClamp: false;
+    lineClamp: boolean;
   }
   interface GxVideo {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled: false;
+    disabled: boolean;
     /**
      * This attribute is for specifies the src of the video.
      */
@@ -2492,7 +2492,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, gxClick event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * Fired when the action sheet item is clicked
      */
@@ -2502,7 +2502,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled.
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute is for specifies the src of the audio.
      */
@@ -2516,7 +2516,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event). If a disabled image has been specified, it will be shown, hiding the base image (if specified).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute lets you specify the height.
      */
@@ -2524,7 +2524,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: true;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify the relative location of the image to the text.  | Value    | Details                                                 | | -------- | ------------------------------------------------------- | | `above`  | The image is located above the text.                    | | `before` | The image is located before the text, in the same line. | | `after`  | The image is located after the text, in the same line.  | | `below`  | The image is located below the text.                    | | `behind` | The image is located behind the text.                   |
      */
@@ -2554,7 +2554,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -2630,7 +2630,7 @@ declare namespace LocalJSX {
     /**
      * True to show the card header. False to hide it.
      */
-    showHeader?: true;
+    showHeader?: boolean;
   }
   interface GxCardHeader {
     /**
@@ -2662,11 +2662,11 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -2678,7 +2678,7 @@ declare namespace LocalJSX {
     /**
      * This attribute indicates that the user cannot modify the value of the control. Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly) attribute for `input` elements.
      */
-    readonly?: false;
+    readonly?: boolean;
     /**
      * The value when the checkbox is 'off'
      */
@@ -2796,7 +2796,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * Used to define the semantic of the element when `readonly="true"`.
      */
@@ -2816,7 +2816,7 @@ declare namespace LocalJSX {
     /**
      * True to cut text when it overflows, showing an ellipsis (only applies when readonly)
      */
-    lineClamp?: false;
+    lineClamp?: boolean;
     /**
      * Controls if the element accepts multiline text.
      */
@@ -2980,7 +2980,7 @@ declare namespace LocalJSX {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows.
      */
-    autoGrow?: false;
+    autoGrow?: boolean;
     /**
      * A CSS class to set as the `gx-grid-flex` element class.
      */
@@ -3028,7 +3028,7 @@ declare namespace LocalJSX {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows.
      */
-    autoGrow?: false;
+    autoGrow?: boolean;
     /**
      * A CSS class to set as the `gx-grid-fs` element class.
      */
@@ -3036,7 +3036,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -3082,7 +3082,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -3196,21 +3196,21 @@ declare namespace LocalJSX {
     /**
      * If `true`, show the scrollbar.
      */
-    scrollbar?: false;
+    scrollbar?: boolean;
     /**
      * If `true`, show the pagination buttons (page controller).
      */
-    showPageController?: true;
+    showPageController?: boolean;
     /**
      * Set to false to enable slides in free mode position.
      */
-    snapToGrid?: true;
+    snapToGrid?: boolean;
   }
   interface GxGridImageMap {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows. This property is not currently supported in the gx-image-map control.
      */
-    autoGrow?: false;
+    autoGrow?: boolean;
     /**
      * A CSS class to set as the `gx-grid-image-map` element class.
      */
@@ -3335,7 +3335,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify the index of the cell. Useful when Inverse Loading is enabled on the grid.
      */
@@ -3343,7 +3343,7 @@ declare namespace LocalJSX {
     /**
      * Whether this row is even position or not. This is specially required in Virtual scroll scenarios where the position in the DOM is not the real position in the collection.
      */
-    isRowEven?: false;
+    isRowEven?: boolean;
     /**
      * Number of Columns to be shown in the grid. Useful when Inverse Loading is enabled on the grid.
      */
@@ -3351,13 +3351,13 @@ declare namespace LocalJSX {
     /**
      * True to show horizontal line.
      */
-    showHorizontalLine?: false;
+    showHorizontalLine?: boolean;
   }
   interface GxGridSmartCss {
     /**
      * This attribute defines if the control size will grow automatically, to adjust to its content size. If set to `false`, it won't grow automatically and it will show scrollbars if the content overflows.
      */
-    autoGrow?: false;
+    autoGrow?: boolean;
     /**
      * A CSS class to set as the `gx-grid-smart-css` element class.
      */
@@ -3395,7 +3395,7 @@ declare namespace LocalJSX {
     /**
      * Scroll snapping allows to lock the viewport to certain elements or locations after a user has finished scrolling
      */
-    snapToGrid?: false;
+    snapToGrid?: boolean;
     /**
      * The threshold distance from the bottom of the content to call the `infinite` output event when scrolled. The threshold value can be either a percent, or in pixels. For example, use the value of `10%` for the `infinite` output event to get called when the user has scrolled 10% from the bottom of the page. Use the value `100px` when the scroll is within 100 pixels from the bottom of the page.
      */
@@ -3417,7 +3417,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
   }
   interface GxHeaderRowPatternMarker {
     /**
@@ -3453,7 +3453,7 @@ declare namespace LocalJSX {
     /**
      * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
      */
-    autoGrow?: true;
+    autoGrow?: boolean;
     /**
      * A CSS class to set as the `gx-image` element class.
      */
@@ -3461,11 +3461,11 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -3473,7 +3473,7 @@ declare namespace LocalJSX {
     /**
      * True to lazy load the image, when it enters the viewport.
      */
-    lazyLoad?: true;
+    lazyLoad?: boolean;
     /**
      * This attribute allows specifing how the image is sized according to its container. `contain`, `cover`, `fill` and `none` map directly to the values of the CSS `object-fit` property. The `tile` value repeats the image, both vertically and horizontally, creating a tile effect.
      */
@@ -3495,7 +3495,7 @@ declare namespace LocalJSX {
     /**
      * If the annotations are activated or not.
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * Specifies the `fontFamily` for the texts
      */
@@ -3555,7 +3555,7 @@ declare namespace LocalJSX {
     /**
      * If true, the component will be sized to match the image's intrinsic size when not constrained via CSS dimension properties (for example, height or width). If false, the component will never force its height to match the image's intrinsic size. The width, however, will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
      */
-    autoGrow?: true;
+    autoGrow?: boolean;
     /**
      * This attribute lets you specify the description of the cancel action button in the modal.
      */
@@ -3571,11 +3571,11 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -3583,7 +3583,7 @@ declare namespace LocalJSX {
     /**
      * True to lazy load the image, when it enters the viewport.
      */
-    lazyLoad?: true;
+    lazyLoad?: boolean;
     /**
      * This attribute lets you specify the modal title.
      */
@@ -3599,7 +3599,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the image is readonly. If readonly, it will not allow to use the edit button. In fact, the edit button will not be shown.
      */
-    readonly?: false;
+    readonly?: boolean;
     /**
      * This attribute lets you specify the description of the remove image button in the modal.
      */
@@ -3643,7 +3643,7 @@ declare namespace LocalJSX {
     /**
      * `false` to hide the bottom target
      */
-    bottomVisible?: false;
+    bottomVisible?: boolean;
     /**
      * This attribute lets you specify if the header row pattern is enabled in the top navbar.
      */
@@ -3675,7 +3675,7 @@ declare namespace LocalJSX {
     /**
      * `false` to hide the top target.
      */
-    topVisible?: false;
+    topVisible?: boolean;
   }
   interface GxLoading {
     /**
@@ -3711,7 +3711,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4059,7 +4059,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if one or two lines will be used to render the navigation bar. Useful when there are links and also actions, to have links in the first line, and actions in the second
      */
-    singleLine?: true;
+    singleLine?: boolean;
     /**
      * This attribute lets you specify the label for the left target toggle button. Important for accessibility.
      */
@@ -4069,7 +4069,7 @@ declare namespace LocalJSX {
     /**
      * Indicates if the navbar item is the active one (for example, when the item represents the current page)
      */
-    active?: false;
+    active?: boolean;
     /**
      * A CSS class to set as the `gx-navbar-item` element class.
      */
@@ -4077,7 +4077,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: true;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify the URL of the navbar item.
      */
@@ -4107,7 +4107,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * The text to set as the label of the gx-password-edit control.
      */
@@ -4187,7 +4187,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4221,7 +4221,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4285,7 +4285,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4319,7 +4319,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * The `change` event is emitted when a change to the element's value is committed by the user.
      */
@@ -4365,7 +4365,7 @@ declare namespace LocalJSX {
     /**
      * This attribute allows you specify if the element is disabled. If disabled, it will not trigger any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4395,7 +4395,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4465,11 +4465,11 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4533,7 +4533,7 @@ declare namespace LocalJSX {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * It specifies the format that will have the textblock control.   - If `format` = `HTML`, the textblock control works as an HTML div and    the innerHTML will be taken from the default slot.   - If `format` = `Text`, the control works as a normal textblock control    and it is affected by most of the defined properties.
      */
@@ -4541,7 +4541,7 @@ declare namespace LocalJSX {
     /**
      * True to highlight control when an action is fired.
      */
-    highlightable?: false;
+    highlightable?: boolean;
     /**
      * This attribute lets you specify how this element will behave when hidden.  | Value        | Details                                                                     | | ------------ | --------------------------------------------------------------------------- | | `keep-space` | The element remains in the document flow, and it does occupy space.         | | `collapse`   | The element is removed form the document flow, and it doesn't occupy space. |
      */
@@ -4549,13 +4549,13 @@ declare namespace LocalJSX {
     /**
      * True to cut text when it overflows, showing an ellipsis.
      */
-    lineClamp?: false;
+    lineClamp?: boolean;
   }
   interface GxVideo {
     /**
      * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event).
      */
-    disabled?: false;
+    disabled?: boolean;
     /**
      * This attribute is for specifies the src of the video.
      */

--- a/src/components/action-sheet-item/action-sheet-item.tsx
+++ b/src/components/action-sheet-item/action-sheet-item.tsx
@@ -3,9 +3,9 @@ import {
   Element,
   Event,
   EventEmitter,
+  Host,
   Prop,
-  h,
-  Host
+  h
 } from "@stencil/core";
 import { Component as GxComponent } from "../common/interfaces";
 
@@ -30,7 +30,7 @@ export class ActionSheetItem implements GxComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, gxClick event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * Fired when the action sheet item is clicked

--- a/src/components/audio/audio.tsx
+++ b/src/components/audio/audio.tsx
@@ -15,7 +15,7 @@ export class Audio implements GxComponent, DisableableComponent {
   /**
    * This attribute lets you specify if the element is disabled.
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute is for specifies the src of the audio.

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -3,26 +3,26 @@ import {
   Element,
   Event,
   EventEmitter,
+  Host,
   Prop,
-  h,
-  Host
+  h
 } from "@stencil/core";
-import {
-  Component as GxComponent,
-  CustomizableComponent,
-  DisableableComponent,
-  VisibilityComponent
-} from "../common/interfaces";
 import {
   HighlightableComponent,
   makeHighlightable
 } from "../common/highlightable";
+import {
+  CustomizableComponent,
+  DisableableComponent,
+  Component as GxComponent,
+  VisibilityComponent
+} from "../common/interfaces";
 
 import { imagePositionClass } from "../common/image-position";
 
 // Class transforms
-import { getClasses } from "../common/css-transforms/css-transforms";
 import { DISABLED_CLASS } from "../../common/reserved-names";
+import { getClasses } from "../common/css-transforms/css-transforms";
 
 const ENTER_KEY_CODE = "Enter";
 const SPACE_KEY_CODE = "Space";
@@ -80,7 +80,7 @@ export class Button
    * (for example, click event). If a disabled image has been specified,
    * it will be shown, hiding the base image (if specified).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute lets you specify the relative location of the image to the text.
@@ -103,7 +103,7 @@ export class Button
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = true;
+  @Prop() readonly highlightable: boolean = true;
 
   /**
    * This attribute lets you specify the width.

--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -11,18 +11,18 @@ import {
   h
 } from "@stencil/core";
 import {
-  Component as GxComponent,
   ClickableComponent,
+  CustomizableComponent,
   DisableableComponent,
-  VisibilityComponent,
-  CustomizableComponent
+  Component as GxComponent,
+  VisibilityComponent
 } from "../common/interfaces";
 
+import { Swipeable, makeSwipeable } from "../common/events/swipeable";
 import {
   HighlightableComponent,
   makeHighlightable
 } from "../common/highlightable";
-import { Swipeable, makeSwipeable } from "../common/events/swipeable";
 
 import { DISABLED_CLASS } from "../../common/reserved-names";
 
@@ -79,7 +79,7 @@ export class Canvas
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.
@@ -163,7 +163,7 @@ export class Canvas
   private autoGrowMechanismStarted = false;
 
   /*  Used to optimize height adjustments. This variable stores the "absolute"
-      maximum height of all gx-canvas-cells with auto-grow = False 
+      maximum height of all gx-canvas-cells with auto-grow = False
   */
   private canvasFixedMinHeight = 0;
 
@@ -221,7 +221,7 @@ export class Canvas
         - If `top="calc(50% + -100px)"` and `min-height="200px"` -> 200 + 0.5 * innerContainerCurrentHeight + -100px
         - If `top="25px"`               and `min-height="200px"` -> 225
         - If `top="25%"`                and `min-height="75%"`   -> 0
-  
+
       `maxCanvasCellHeight` determines the max value of all "absolute heights".
       We use this variable to update the gx-canvas minHeight and to determinate
       if there is a gx-canvas-cell with auto-grow = False that is taller than
@@ -310,7 +310,7 @@ export class Canvas
       }
 
       /*  If the canvas decreased its height and there is a gx-canvas-cell that
-          provokes overflow-y, we fix the canvas height 
+          provokes overflow-y, we fix the canvas height
       */
       const maxHeightConstraint = this.getMaxHeightConstraint();
       if (
@@ -418,7 +418,7 @@ export class Canvas
 
   /*  This functions is called the first time that
         this.canvasFixedHeight != null
-  
+
       Due to at this point we have to resize the gx-canvas, we fix the relative
       values of top, min-height and max-height in all the gx-canvas-cell
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -17,7 +17,7 @@ export class Card implements GxComponent {
   /**
    * True to show the card header. False to hide it.
    */
-  @Prop() readonly showHeader = true;
+  @Prop() readonly showHeader: boolean = true;
 
   render() {
     return (

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,16 +1,16 @@
-import { CheckBoxRender } from "../renders/bootstrap/checkbox/checkbox-render";
 import {
   Component,
   Element,
   Event,
   EventEmitter,
+  Host,
   Method,
   Prop,
   Watch,
-  Host,
   h
 } from "@stencil/core";
 import { FormComponent } from "../common/interfaces";
+import { CheckBoxRender } from "../renders/bootstrap/checkbox/checkbox-render";
 
 // Class transforms
 import { getClasses } from "../common/css-transforms/css-transforms";
@@ -56,12 +56,12 @@ export class CheckBox implements FormComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.
@@ -78,7 +78,7 @@ export class CheckBox implements FormComponent {
    * Same as [readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly)
    * attribute for `input` elements.
    */
-  @Prop() readonly readonly = false;
+  @Prop() readonly readonly: boolean = false;
 
   /**
    * The value when the checkbox is 'off'

--- a/src/components/edit/edit.tsx
+++ b/src/components/edit/edit.tsx
@@ -21,13 +21,13 @@ import {
 } from "../common/interfaces";
 import { makeLinesClampable } from "../common/line-clamp";
 
-import { EditType, FontCategory } from "../../common/types";
 import {
   DISABLED_CLASS,
   HEIGHT_MEASURING,
   LINE_CLAMP,
   LINE_MEASURING
 } from "../../common/reserved-names";
+import { EditType, FontCategory } from "../../common/types";
 
 // Class transforms
 import { getClasses } from "../common/css-transforms/css-transforms";
@@ -148,7 +148,7 @@ export class Edit
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * Used to define the semantic of the element when `readonly="true"`.
@@ -163,7 +163,7 @@ export class Edit
   /**
    * True to cut text when it overflows, showing an ellipsis (only applies when readonly)
    */
-  @Prop() readonly lineClamp = false;
+  @Prop() readonly lineClamp: boolean = false;
 
   /**
    * Controls if the element accepts multiline text.

--- a/src/components/grid-flex/grid-flex.tsx
+++ b/src/components/grid-flex/grid-flex.tsx
@@ -7,13 +7,13 @@ import {
   Host,
   Method,
   Prop,
-  h,
-  Watch
+  Watch,
+  h
 } from "@stencil/core";
 import { GridBase, GridBaseHelper } from "../grid-base/grid-base";
 
-import { VisibilityComponent } from "../common/interfaces";
 import { FlexDirection, FlexWrap, ScrollDirection } from "../../common/types";
+import { VisibilityComponent } from "../common/interfaces";
 
 const VERTICAL_SCROLL: ScrollDirection = "vertical";
 const HORIZONTAL_SCROLL: ScrollDirection = "horizontal";
@@ -121,7 +121,7 @@ export class GridFlex
    * If set to `false`, it won't grow automatically and it will show scrollbars
    * if the content overflows.
    */
-  @Prop() readonly autoGrow = false;
+  @Prop() readonly autoGrow: boolean = false;
 
   /**
    * A CSS class to set as the `gx-grid-flex` element class.

--- a/src/components/grid-fs/grid-fs.tsx
+++ b/src/components/grid-fs/grid-fs.tsx
@@ -40,7 +40,7 @@ export class GridFreeStyle
    * If set to `false`, it won't grow automatically and it will show scrollbars
    * if the content overflows.
    */
-  @Prop() readonly autoGrow = false;
+  @Prop() readonly autoGrow: boolean = false;
 
   /**
    * A CSS class to set as the `gx-grid-fs` element class.
@@ -88,7 +88,7 @@ export class GridFreeStyle
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This Handler will be called every time grid threshold is reached. Needed for infinite scrolling grids.

--- a/src/components/grid-horizontal/grid-horizontal.tsx
+++ b/src/components/grid-horizontal/grid-horizontal.tsx
@@ -10,8 +10,8 @@ import {
   Watch,
   h
 } from "@stencil/core";
-import { GridBase, GridBaseHelper } from "../grid-base/grid-base";
 import Swiper, { FreeMode, Grid, Pagination, SwiperOptions } from "swiper";
+import { GridBase, GridBaseHelper } from "../grid-base/grid-base";
 
 import { HighlightableComponent } from "../common/highlightable";
 import { VisibilityComponent } from "../common/interfaces";
@@ -133,22 +133,22 @@ export class GridHorizontal
   /**
    * If `true`, show the scrollbar.
    */
-  @Prop() readonly scrollbar = false;
+  @Prop() readonly scrollbar: boolean = false;
 
   /**
    * If `true`, show the pagination buttons (page controller).
    */
-  @Prop() readonly showPageController = true;
+  @Prop() readonly showPageController: boolean = true;
 
   /**
    * Set to false to enable slides in free mode position.
    */
-  @Prop() readonly snapToGrid = true;
+  @Prop() readonly snapToGrid: boolean = true;
 
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This Handler will be called every time grid threshold is reached. Needed for infinite scrolling grids.

--- a/src/components/grid-image-map/grid-image-map.tsx
+++ b/src/components/grid-image-map/grid-image-map.tsx
@@ -1,26 +1,26 @@
 import {
   Component,
-  Host,
-  h,
-  Prop,
   Element,
   Event,
   EventEmitter,
+  Host,
   Listen,
-  State
+  Prop,
+  State,
+  h
 } from "@stencil/core";
 import "custom-pinch-zoom-element";
 
-import { Component as GxComponent } from "../common/interfaces";
-import { GridBase, GridBaseHelper } from "../grid-base/grid-base";
-import {
-  HighlightableComponent,
-  makeHighlightable
-} from "../common/highlightable";
 import {
   LongPressComponent,
   makeLongPressable
 } from "../common/events/long-press";
+import {
+  HighlightableComponent,
+  makeHighlightable
+} from "../common/highlightable";
+import { Component as GxComponent } from "../common/interfaces";
+import { GridBase, GridBaseHelper } from "../grid-base/grid-base";
 
 // Class transforms
 import { getClasses } from "../common/css-transforms/css-transforms";
@@ -62,7 +62,7 @@ export class GridImageMap
    * if the content overflows.
    * This property is not currently supported in the gx-image-map control.
    */
-  @Prop() readonly autoGrow = false;
+  @Prop() readonly autoGrow: boolean = false;
 
   /**
    * A CSS class to set as the `gx-grid-image-map` element class.

--- a/src/components/grid-smart-cell/grid-smart-cell.tsx
+++ b/src/components/grid-smart-cell/grid-smart-cell.tsx
@@ -37,7 +37,7 @@ export class GridSmartCell
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This attribute lets you specify the index of the cell. Useful when Inverse
@@ -49,7 +49,7 @@ export class GridSmartCell
    * Whether this row is even position or not. This is specially required in Virtual scroll scenarios
    * where the position in the DOM is not the real position in the collection.
    */
-  @Prop({ reflect: true }) readonly isRowEven = false;
+  @Prop({ reflect: true }) readonly isRowEven: boolean = false;
 
   /**
    * Number of Columns to be shown in the grid. Useful when Inverse Loading is
@@ -60,7 +60,7 @@ export class GridSmartCell
   /**
    * True to show horizontal line.
    */
-  @Prop() readonly showHorizontalLine = false;
+  @Prop() readonly showHorizontalLine: boolean = false;
 
   componentWillLoad() {
     // Not null when inverse loading is enabled

--- a/src/components/grid-smart-css/grid-smart-css.tsx
+++ b/src/components/grid-smart-css/grid-smart-css.tsx
@@ -7,8 +7,8 @@ import {
   Host,
   Method,
   Prop,
-  h,
-  Watch
+  Watch,
+  h
 } from "@stencil/core";
 import { GridBase, GridBaseHelper } from "../grid-base/grid-base";
 
@@ -47,7 +47,7 @@ export class GridSmartCss
    * If set to `false`, it won't grow automatically and it will show scrollbars
    * if the content overflows.
    */
-  @Prop() readonly autoGrow = false;
+  @Prop() readonly autoGrow: boolean = false;
 
   /**
    * A CSS class to set as the `gx-grid-smart-css` element class.
@@ -116,7 +116,7 @@ export class GridSmartCss
   /**
    * Scroll snapping allows to lock the viewport to certain elements or locations after a user has finished scrolling
    */
-  @Prop({ reflect: true }) readonly snapToGrid = false;
+  @Prop({ reflect: true }) readonly snapToGrid: boolean = false;
 
   /**
    * This Handler will be called every time grid threshold is reached. Needed for infinite scrolling grids.

--- a/src/components/group/group.tsx
+++ b/src/components/group/group.tsx
@@ -41,7 +41,7 @@ export class Group implements GxComponent, HighlightableComponent {
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   private fieldsetElement: HTMLFieldSetElement;
 

--- a/src/components/image-annotations/image-annotations.tsx
+++ b/src/components/image-annotations/image-annotations.tsx
@@ -1,13 +1,13 @@
 import {
   Component,
-  Host,
-  h,
   Element,
+  Event,
+  EventEmitter,
+  Host,
   Prop,
   State,
   Watch,
-  Event,
-  EventEmitter
+  h
 } from "@stencil/core";
 
 const EMPTY_TRACE_LIST_INDEX = -3;
@@ -53,7 +53,7 @@ export class GxImageAnnotations {
   /**
    * If the annotations are activated or not.
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * Specifies the `fontFamily` for the texts

--- a/src/components/image-picker/image-picker.tsx
+++ b/src/components/image-picker/image-picker.tsx
@@ -41,7 +41,7 @@ export class ImagePicker implements GxComponent {
    * If false, the component will never force its height to match the image's intrinsic size. The width, however,
    * will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
    */
-  @Prop() readonly autoGrow = true;
+  @Prop() readonly autoGrow: boolean = true;
 
   /**
    * A CSS class to set as the `gx-image-picker` element class.
@@ -53,7 +53,7 @@ export class ImagePicker implements GxComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.
@@ -68,7 +68,7 @@ export class ImagePicker implements GxComponent {
   /**
    * True to lazy load the image, when it enters the viewport.
    */
-  @Prop() readonly lazyLoad = true;
+  @Prop() readonly lazyLoad: boolean = true;
 
   /**
    * This attribute allows specifing how the image is sized according to its container.
@@ -90,14 +90,14 @@ export class ImagePicker implements GxComponent {
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This attribute lets you specify if the image is readonly.
    * If readonly, it will not allow to use the edit button.
    * In fact, the edit button will not be shown.
    */
-  @Prop() readonly readonly = false;
+  @Prop() readonly readonly: boolean = false;
 
   /**
    * This attribute lets you specify the modal title.

--- a/src/components/image/image.tsx
+++ b/src/components/image/image.tsx
@@ -1,13 +1,13 @@
 import { Component, Element, Host, Listen, Prop, h } from "@stencil/core";
 import {
+  HighlightableComponent,
+  makeHighlightable
+} from "../common/highlightable";
+import {
   DisableableComponent,
   Component as GxComponent,
   VisibilityComponent
 } from "../common/interfaces";
-import {
-  HighlightableComponent,
-  makeHighlightable
-} from "../common/highlightable";
 
 import { cssVariablesWatcher } from "../common/css-variables-watcher";
 
@@ -65,7 +65,7 @@ export class Image
    * If false, the component will never force its height to match the image's intrinsic size. The width, however,
    * will match the intrinsic width. In GeneXus terms, it will auto grow horizontally, but not vertically.
    */
-  @Prop() readonly autoGrow = true;
+  @Prop() readonly autoGrow: boolean = true;
 
   /**
    * A CSS class to set as the `gx-image` element class.
@@ -77,7 +77,7 @@ export class Image
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.
@@ -92,7 +92,7 @@ export class Image
   /**
    * True to lazy load the image, when it enters the viewport.
    */
-  @Prop() readonly lazyLoad = true;
+  @Prop() readonly lazyLoad: boolean = true;
 
   /**
    * This attribute allows specifing how the image is sized according to its container.
@@ -127,7 +127,7 @@ export class Image
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   @Listen("click", { capture: true })
   handleClick(event: UIEvent) {

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -32,7 +32,7 @@ export class Layout implements GxComponent {
   /**
    * `false` to hide the bottom target
    */
-  @Prop() readonly bottomVisible = false;
+  @Prop() readonly bottomVisible: boolean = false;
 
   /**
    * This attribute lets you specify if the header row pattern is enabled in
@@ -64,7 +64,7 @@ export class Layout implements GxComponent {
   /**
    * `false` to hide the top target.
    */
-  @Prop() readonly topVisible = false;
+  @Prop() readonly topVisible: boolean = false;
 
   @State() isMaskVisible = this.rightVisible || this.leftVisible;
 

--- a/src/components/lottie/lottie.tsx
+++ b/src/components/lottie/lottie.tsx
@@ -11,8 +11,8 @@ import {
 import bodymovin from "lottie-web/build/player/lottie_light";
 import {
   ClickableComponent,
-  Component as GxComponent,
   DisableableComponent,
+  Component as GxComponent,
   VisibilityComponent
 } from "../common/interfaces";
 
@@ -63,7 +63,7 @@ export class Lottie
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute lets you specify if the animation will loop

--- a/src/components/navbar-item/navbar-item.tsx
+++ b/src/components/navbar-item/navbar-item.tsx
@@ -1,14 +1,14 @@
 import { Component, Element, Host, Prop, h } from "@stencil/core";
-import { Component as GxComponent, LayoutSize } from "../common/interfaces";
 import {
   HighlightableComponent,
   makeHighlightable
 } from "../common/highlightable";
+import { Component as GxComponent, LayoutSize } from "../common/interfaces";
 
 // Class transforms
 import {
-  getClasses,
-  HIGHLIGHT_CLASS_NAME
+  HIGHLIGHT_CLASS_NAME,
+  getClasses
 } from "../common/css-transforms/css-transforms";
 
 @Component({
@@ -22,7 +22,7 @@ export class NavBarItem implements GxComponent, HighlightableComponent {
   /**
    * Indicates if the navbar item is the active one (for example, when the item represents the current page)
    */
-  @Prop() readonly active = false;
+  @Prop() readonly active: boolean = false;
 
   /**
    * A CSS class to set as the `gx-navbar-item` element class.
@@ -32,7 +32,7 @@ export class NavBarItem implements GxComponent, HighlightableComponent {
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = true;
+  @Prop() readonly highlightable: boolean = true;
 
   /**
    * This attribute lets you specify the URL of the navbar item.

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -1,12 +1,12 @@
 import {
   Component,
   Element,
-  Prop,
-  h,
-  Host,
   Event,
   EventEmitter,
-  State
+  Host,
+  Prop,
+  State,
+  h
 } from "@stencil/core";
 import { Component as GxComponent, LayoutSize } from "../common/interfaces";
 import { watchForItems } from "../common/watch-items";
@@ -122,7 +122,7 @@ export class NavBar implements GxComponent {
    * This attribute lets you specify if one or two lines will be used to render the navigation bar.
    * Useful when there are links and also actions, to have links in the first line, and actions in the second
    */
-  @Prop() readonly singleLine = true;
+  @Prop() readonly singleLine: boolean = true;
 
   /**
    * This attribute lets you specify the label for the left target toggle button. Important for accessibility.

--- a/src/components/password-edit/password-edit.tsx
+++ b/src/components/password-edit/password-edit.tsx
@@ -3,16 +3,16 @@ import {
   Element,
   Event,
   EventEmitter,
-  Listen,
   Host,
+  Listen,
   Method,
   Prop,
   State,
   h
 } from "@stencil/core";
 import {
-  Component as GxComponent,
-  DisableableComponent
+  DisableableComponent,
+  Component as GxComponent
 } from "../common/interfaces";
 
 @Component({
@@ -41,7 +41,7 @@ export class PasswordEdit implements GxComponent, DisableableComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * The text to set as the label of the gx-password-edit control.

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -3,15 +3,15 @@ import {
   Element,
   Event,
   EventEmitter,
+  Host,
   Listen,
   Prop,
   Watch,
-  h,
-  Host
+  h
 } from "@stencil/core";
 import {
-  Component as GxComponent,
   DisableableComponent,
+  Component as GxComponent,
   VisibilityComponent
 } from "../common/interfaces";
 
@@ -60,7 +60,7 @@ export class RadioGroup
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * The name that will be set to all the inner inputs of type radio

--- a/src/components/radio-option/radio-option.tsx
+++ b/src/components/radio-option/radio-option.tsx
@@ -3,17 +3,17 @@ import {
   Element,
   Event,
   EventEmitter,
+  Host,
   Prop,
   Watch,
-  Host,
   h
 } from "@stencil/core";
-import { RadioOptionRender } from "../renders/bootstrap/radio-option/radio-option-render";
 import {
-  Component as GxComponent,
   DisableableComponent,
+  Component as GxComponent,
   VisibilityComponent
 } from "../common/interfaces";
+import { RadioOptionRender } from "../renders/bootstrap/radio-option/radio-option-render";
 
 @Component({
   shadow: false,
@@ -56,7 +56,7 @@ export class RadioOption
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * The name of the inner input of type radio

--- a/src/components/select-option/select-option.tsx
+++ b/src/components/select-option/select-option.tsx
@@ -3,14 +3,14 @@ import {
   Element,
   Event,
   EventEmitter,
+  Host,
   Prop,
   Watch,
-  h,
-  Host
+  h
 } from "@stencil/core";
 import {
-  Component as GxComponent,
-  DisableableComponent
+  DisableableComponent,
+  Component as GxComponent
 } from "../common/interfaces";
 
 @Component({
@@ -35,7 +35,7 @@ export class SelectOption implements GxComponent, DisableableComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * The initial value of the control.

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -9,8 +9,8 @@ import {
   State,
   Watch
 } from "@stencil/core";
-import { SelectRender } from "../renders/bootstrap/select/select-render";
 import { FormComponent } from "../common/interfaces";
+import { SelectRender } from "../renders/bootstrap/select/select-render";
 
 @Component({
   shadow: false,
@@ -52,7 +52,7 @@ export class Select implements FormComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute indicates that the user cannot modify the value of the control.

--- a/src/components/switch/switch.tsx
+++ b/src/components/switch/switch.tsx
@@ -3,10 +3,10 @@ import {
   Element,
   Event,
   EventEmitter,
+  Host,
   Method,
   Prop,
-  h,
-  Host
+  h
 } from "@stencil/core";
 import { FormComponent } from "../common/interfaces";
 
@@ -53,7 +53,7 @@ export class Switch implements FormComponent {
    * If disabled, it will not trigger any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -9,13 +9,13 @@ import {
   h
 } from "@stencil/core";
 import {
-  Component as GxComponent,
-  VisibilityComponent
-} from "../common/interfaces";
-import {
   HighlightableComponent,
   makeHighlightable
 } from "../common/highlightable";
+import {
+  Component as GxComponent,
+  VisibilityComponent
+} from "../common/interfaces";
 
 // Class transforms
 import { getClasses } from "../common/css-transforms/css-transforms";
@@ -67,7 +67,7 @@ export class Tab
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * Defines how the tabs will be distributed in the Strip.

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -8,17 +8,17 @@ import {
   Prop,
   h
 } from "@stencil/core";
-import {
-  DisableableComponent,
-  Component as GxComponent,
-  CustomizableComponent,
-  VisibilityComponent
-} from "../common/interfaces";
+import { Swipeable, makeSwipeable } from "../common/events/swipeable";
 import {
   HighlightableComponent,
   makeHighlightable
 } from "../common/highlightable";
-import { Swipeable, makeSwipeable } from "../common/events/swipeable";
+import {
+  CustomizableComponent,
+  DisableableComponent,
+  Component as GxComponent,
+  VisibilityComponent
+} from "../common/interfaces";
 
 import { DISABLED_CLASS } from "../../common/reserved-names";
 
@@ -68,12 +68,12 @@ export class Table
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.

--- a/src/components/textblock/textblock.tsx
+++ b/src/components/textblock/textblock.tsx
@@ -8,14 +8,14 @@ import {
   h
 } from "@stencil/core";
 import {
+  HighlightableComponent,
+  makeHighlightable
+} from "../common/highlightable";
+import {
   DisableableComponent,
   Component as GxComponent,
   VisibilityComponent
 } from "../common/interfaces";
-import {
-  HighlightableComponent,
-  makeHighlightable
-} from "../common/highlightable";
 import { LineClampComponent, makeLinesClampable } from "../common/line-clamp";
 
 import {
@@ -71,7 +71,7 @@ export class TextBlock
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop({ reflect: true }) readonly disabled = false;
+  @Prop({ reflect: true }) readonly disabled: boolean = false;
 
   /**
    * It specifies the format that will have the textblock control.
@@ -87,7 +87,7 @@ export class TextBlock
   /**
    * True to highlight control when an action is fired.
    */
-  @Prop() readonly highlightable = false;
+  @Prop() readonly highlightable: boolean = false;
 
   /**
    * This attribute lets you specify how this element will behave when hidden.
@@ -102,7 +102,7 @@ export class TextBlock
   /**
    * True to cut text when it overflows, showing an ellipsis.
    */
-  @Prop() readonly lineClamp = false;
+  @Prop() readonly lineClamp: boolean = false;
 
   @Listen("click", { capture: true })
   handleClick(event: UIEvent) {

--- a/src/components/video/video.tsx
+++ b/src/components/video/video.tsx
@@ -1,8 +1,8 @@
 import { Component, Element, Host, Prop, h } from "@stencil/core";
 
 import {
-  Component as GxComponent,
-  DisableableComponent
+  DisableableComponent,
+  Component as GxComponent
 } from "../common/interfaces";
 
 @Component({
@@ -18,7 +18,7 @@ export class Video implements GxComponent, DisableableComponent {
    * If disabled, it will not fire any user interaction related event
    * (for example, click event).
    */
-  @Prop() readonly disabled = false;
+  @Prop() readonly disabled: boolean = false;
 
   /**
    * This attribute is for specifies the src of the video.


### PR DESCRIPTION
Typescript has not inferred correctly the type when the value property is declared in a Stencil @Prop

```
   // dist/types/components.d.ts

    interface GxButton {
        /**
          * A CSS class to set as the `gx-button` element class.
         */
        "cssClass"?: string;
        /**
          * This attribute lets you specify if the element is disabled. If disabled, it will not fire any user interaction related event (for example, click event). If a disabled image has been specified, it will be shown, hiding the base image (if specified).
         */
        "disabled"?: false; <--
        /**
          * This attribute lets you specify the height.
         */
        "height"?: string;
        /**
          * True to highlight control when an action is fired.
         */
        "highlightable"?: true; <--
        /**
}
```